### PR TITLE
fix: align node version in docker file with package.json - [CU-869atv8pc]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim AS base
+FROM node:22-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 WORKDIR /app


### PR DESCRIPTION
## Description
Fixed a version conflict between the dockerfile & package.json by upgrading the dockerfile to use the newer version `22.x`

## Reviewer Guidance
Check if it runs correctly without getting a warn similar to this
` WARN  Unsupported engine: wanted: {"node":">=22.0.0"} (current: {"node":"v20.19.5","pnpm":"10.15.1"})`