### PR TITLE
fix(workflow): main branch protection workflow false triggers - [CU-869atvhvj]

### DIFF
--- a/.github/workflows/main-merge-protection.yaml
+++ b/.github/workflows/main-merge-protection.yaml
@@ -11,10 +11,11 @@ jobs:
     steps:
       - name: Verify Authorized User
         run: |
+          TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
           PR_AUTHOR="${{ github.actor }}"
           ALLOWED_USER="AhmedSobhy01"
 
-          if [ "$PR_AUTHOR" != "$ALLOWED_USER" ]; then
+          if [ "$PR_AUTHOR" != "$ALLOWED_USER" ] && [ "$TARGET_BRANCH" = "main" ]; then
             echo "Unauthorized PR to main by $PR_AUTHOR, only $ALLOWED_USER is allowed."
             exit 1
           fi


### PR DESCRIPTION
An edge case that causes the workflow to get triggered once and never again on the same PR (caching the response, hence always failing)