### PR TITLE
feat: tweet core logic and data - [CU-869atuury]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ logs
 
 # ignore testing coverage folder
 /coverage
+
+# ignore mock data folder
+/mocks/data/*
+!/mocks/data/.gitkeep

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,4 +7,3 @@ public
 .github
 pnpm-lock.yaml
 .pnpm-store
-package.json

--- a/app/pages/playground/tweet.vue
+++ b/app/pages/playground/tweet.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { Tweet } from '~~/types/tweets';
+const tweets = ref<Tweet[]>([]);
+
+const { data: tweetsData, error } = useFetch<{ data: Tweet[] }>('/api/tweets');
+tweets.value = tweetsData.value?.data || [];
+
+if (error.value) console.error(error.value);
+</script>
+
+<template>
+  <div class="p-4">
+    <h1 v-if="tweets[1]" class="mb-4 text-2xl font-bold">
+      {{ tweets[1].id }}
+    </h1>
+    <h1 v-else>{{ $t('testing.tweets.tweet-not-found') }}</h1>
+  </div>
+</template>

--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -10,7 +10,10 @@
     "follow": "متابعة",
     "unfollow": "إلغاء المتابعة",
     "following": "متابع",
-    "subscribe": "الاشتراك"
+    "subscribe": "الاشتراك",
+    "tweets": {
+      "tweet-not-found": "التغريدة غير موجودة"
+    }
   },
   "root": {
     "hero": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -10,6 +10,9 @@
     "user": {
       "name": "John Doe",
       "username": "johndoe"
+    },
+    "tweets": {
+      "tweet-not-found": "Tweet not found"
     }
   },
   "root": {

--- a/mocks/generators/genMockTweets.ts
+++ b/mocks/generators/genMockTweets.ts
@@ -1,0 +1,103 @@
+import { faker } from '@faker-js/faker';
+import { mkdirSync, writeFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import type { Tweet } from '../../types/tweets';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function makeAuthor(index: number) {
+  const username = faker.internet.userName().toLowerCase() + index;
+  return {
+    username,
+    displayName: faker.person.fullName(),
+    avatarUrl: `/avatars/${username}.png`,
+    isFollowing: faker.datatype.boolean(),
+    isFollower: faker.datatype.boolean(),
+  };
+}
+
+function randomEntities() {
+  const mentionsCount = faker.number.int({ min: 0, max: 2 });
+  const hashtagsCount = faker.number.int({ min: 0, max: 2 });
+  const mentions = Array.from({ length: mentionsCount }, () => ({
+    username: faker.internet.userName().toLowerCase(),
+    startPosition: faker.number.int({ min: 0, max: 20 }),
+  }));
+  const hashtags = Array.from({ length: hashtagsCount }, () => ({
+    hashtag: faker.hacker.noun().replace(/\s+/g, ''),
+    startPosition: faker.number.int({ min: 0, max: 20 }),
+  }));
+  return { mentions, hashtags };
+}
+
+function randomMedia() {
+  const shouldHaveMedia = faker.datatype.boolean(0.3);
+  if (!shouldHaveMedia) return [] as Tweet['media'];
+  const types = ['IMAGE', 'GIF', 'VIDEO'] as const;
+  const type = faker.helpers.arrayElement(types);
+  return [
+    {
+      type,
+      url: faker.internet.url(),
+      altText: faker.lorem.sentence(),
+      width: faker.number.int({ min: 320, max: 1920 }),
+      height: faker.number.int({ min: 240, max: 1080 }),
+    },
+  ] as Tweet['media'];
+}
+
+function makeBaseTweet(id: string, content?: string): Tweet {
+  return {
+    id,
+    content: content ?? faker.lorem.sentences({ min: 1, max: 3 }),
+    createdAt: new Date().toISOString(),
+    author: makeAuthor(faker.number.int({ min: 1, max: 999 })),
+    replyCount: 0,
+    retweetCount: faker.number.int({ min: 0, max: 100 }),
+    likeCount: faker.number.int({ min: 0, max: 500 }),
+    isLiked: faker.datatype.boolean(),
+    isRetweeted: faker.datatype.boolean(),
+    entities: randomEntities(),
+    media: randomMedia(),
+  };
+}
+
+function makeData() {
+  const t1: Tweet = makeBaseTweet('tw-' + faker.string.nanoid(6));
+
+  const t2: Tweet = makeBaseTweet('tw-' + faker.string.nanoid(6));
+  const t3: Tweet = {
+    ...makeBaseTweet('tw-' + faker.string.nanoid(6), faker.lorem.sentences({ min: 1, max: 2 })),
+    isReplyToTweetId: t1.id,
+  };
+  t1.replyCount += 1;
+
+  const quotedLight: Tweet = {
+    ...t1,
+    quotedTweet: undefined,
+    quotedTweetId: undefined,
+    isReplyToTweetId: undefined,
+  };
+  const t4: Tweet = {
+    ...makeBaseTweet('tw-' + faker.string.nanoid(6), faker.lorem.sentences({ min: 1, max: 2 })),
+    quotedTweetId: t1.id,
+    quotedTweet: quotedLight,
+  };
+
+  const tweets: Tweet[] = [t1, t2, t3, t4];
+  return tweets;
+}
+
+function main() {
+  const data = makeData();
+  const outDir = path.resolve(__dirname, '../data');
+  const outFile = path.join(outDir, 'tweet.json');
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(outFile, JSON.stringify(data, null, 2), 'utf-8');
+  // eslint-disable-next-line no-console
+  console.log(`Wrote ${data.length} tweets to ${path.relative(process.cwd(), outFile)}`);
+}
+
+main();

--- a/mocks/generators/genMockTweets.ts
+++ b/mocks/generators/genMockTweets.ts
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 function makeAuthor(index: number) {
-  const username = faker.internet.userName().toLowerCase() + index;
+  const username = faker.internet.username().toLowerCase() + index;
   return {
     username,
     displayName: faker.person.fullName(),
@@ -22,7 +22,7 @@ function randomEntities() {
   const mentionsCount = faker.number.int({ min: 0, max: 2 });
   const hashtagsCount = faker.number.int({ min: 0, max: 2 });
   const mentions = Array.from({ length: mentionsCount }, () => ({
-    username: faker.internet.userName().toLowerCase(),
+    username: faker.internet.username().toLowerCase(),
     startPosition: faker.number.int({ min: 0, max: 20 }),
   }));
   const hashtags = Array.from({ length: hashtagsCount }, () => ({
@@ -96,7 +96,7 @@ function main() {
   const outFile = path.join(outDir, 'tweet.json');
   mkdirSync(outDir, { recursive: true });
   writeFileSync(outFile, JSON.stringify(data, null, 2), 'utf-8');
-  // eslint-disable-next-line no-console
+
   // console.log(`Wrote ${data.length} tweets to ${path.relative(process.cwd(), outFile)}`);
 }
 

--- a/mocks/generators/genMockTweets.ts
+++ b/mocks/generators/genMockTweets.ts
@@ -97,7 +97,7 @@ function main() {
   mkdirSync(outDir, { recursive: true });
   writeFileSync(outFile, JSON.stringify(data, null, 2), 'utf-8');
   // eslint-disable-next-line no-console
-  console.log(`Wrote ${data.length} tweets to ${path.relative(process.cwd(), outFile)}`);
+  // console.log(`Wrote ${data.length} tweets to ${path.relative(process.cwd(), outFile)}`);
 }
 
 main();

--- a/mocks/handler.ts
+++ b/mocks/handler.ts
@@ -1,7 +1,9 @@
 import { handlers as userHandlers } from './handlers/user';
+import { handlers as tweetHandlers } from './handlers/tweet';
 // Import more handlers as needed
 
 export const handlers = [
   ...userHandlers,
+  ...tweetHandlers,
   // Add More handlers here
 ];

--- a/mocks/handlers/tweet.ts
+++ b/mocks/handlers/tweet.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw';
 import type { Tweet } from '../../types/tweets';
 import tweetsData from '../data/tweet.json' assert { type: 'json' };
 
-const API_URL = '';
+const API_URL = process.env.BACKEND_URL;
 const initialTweets = (tweetsData as unknown as Tweet[]) || [];
 const tweets = new Map<string, Tweet>(initialTweets.map((t) => [t.id, { ...t }]));
 
@@ -37,6 +37,18 @@ const unretweet = (t: Tweet) => {
 };
 
 export const handlers = [
+  // Get All Tweets
+  http.get(`${API_URL}/tweets`, () => {
+    return HttpResponse.json(
+      {
+        success: true,
+        message: 'Tweets fetched successfully.',
+        data: Array.from(tweets.values()),
+      },
+      { status: 200 },
+    );
+  }),
+
   // GET /tweets/:id — fetch a tweet by id
   http.get(`${API_URL}/tweets/:id`, ({ params }) => {
     const { id } = params as { id: string };

--- a/mocks/handlers/tweet.ts
+++ b/mocks/handlers/tweet.ts
@@ -1,0 +1,124 @@
+import { http, HttpResponse } from 'msw';
+import type { Tweet } from '../../types/tweets';
+import tweetsData from '../data/tweet.json' assert { type: 'json' };
+
+const API_URL = '';
+const initialTweets = (tweetsData as unknown as Tweet[]) || [];
+const tweets = new Map<string, Tweet>(initialTweets.map((t) => [t.id, { ...t }]));
+
+const getTweet = (id: string) => tweets.get(id);
+
+const likeTweet = (t: Tweet) => {
+  if (!t.isLiked) {
+    t.isLiked = true;
+    t.likeCount += 1;
+  }
+};
+
+const unlikeTweet = (t: Tweet) => {
+  if (t.isLiked) {
+    t.isLiked = false;
+    t.likeCount = Math.max(0, t.likeCount - 1);
+  }
+};
+
+const retweet = (t: Tweet) => {
+  if (!t.isRetweeted) {
+    t.isRetweeted = true;
+    t.retweetCount += 1;
+  }
+};
+
+const unretweet = (t: Tweet) => {
+  if (t.isRetweeted) {
+    t.isRetweeted = false;
+    t.retweetCount = Math.max(0, t.retweetCount - 1);
+  }
+};
+
+export const handlers = [
+  // GET /tweets/:id — fetch a tweet by id
+  http.get(`${API_URL}/tweets/:id`, ({ params }) => {
+    const { id } = params as { id: string };
+    const tweet = getTweet(id);
+    if (!tweet) {
+      return HttpResponse.json({ message: `Tweet "${id}" not found` }, { status: 404 });
+    }
+    return HttpResponse.json(
+      {
+        success: true,
+        message: 'Tweet fetched successfully.',
+        data: tweet,
+      },
+      { status: 200 },
+    );
+  }),
+
+  // POST /tweets/:id/like — like a tweet
+  http.post(`${API_URL}/tweets/:id/like`, ({ params }) => {
+    const { id } = params as { id: string };
+    const tweet = getTweet(id);
+    if (!tweet) {
+      return HttpResponse.json({ message: `Tweet "${id}" not found` }, { status: 404 });
+    }
+    if (tweet.isLiked) {
+      return HttpResponse.json({ message: 'Tweet already liked.' }, { status: 409 });
+    }
+    likeTweet(tweet);
+    return HttpResponse.json(
+      { success: true, message: 'Tweet liked successfully.' },
+      { status: 200 },
+    );
+  }),
+
+  // DELETE /tweets/:id/like — unlike a tweet
+  http.delete(`${API_URL}/tweets/:id/like`, ({ params }) => {
+    const { id } = params as { id: string };
+    const tweet = getTweet(id);
+    if (!tweet) {
+      return HttpResponse.json({ message: `Tweet "${id}" not found` }, { status: 404 });
+    }
+    if (!tweet.isLiked) {
+      return HttpResponse.json({ message: 'Tweet is not liked.' }, { status: 400 });
+    }
+    unlikeTweet(tweet);
+    return HttpResponse.json(
+      { success: true, message: 'Tweet unliked successfully.' },
+      { status: 200 },
+    );
+  }),
+
+  // POST /tweets/:id/retweet — retweet a tweet
+  http.post(`${API_URL}/tweets/:id/retweet`, ({ params }) => {
+    const { id } = params as { id: string };
+    const tweet = getTweet(id);
+    if (!tweet) {
+      return HttpResponse.json({ message: `Tweet "${id}" not found` }, { status: 404 });
+    }
+    if (tweet.isRetweeted) {
+      return HttpResponse.json({ message: 'Tweet already retweeted.' }, { status: 409 });
+    }
+    retweet(tweet);
+    return HttpResponse.json(
+      { success: true, message: 'Tweet retweeted successfully.' },
+      { status: 200 },
+    );
+  }),
+
+  // DELETE /tweets/:id/retweet — undo retweet
+  http.delete(`${API_URL}/tweets/:id/retweet`, ({ params }) => {
+    const { id } = params as { id: string };
+    const tweet = getTweet(id);
+    if (!tweet) {
+      return HttpResponse.json({ message: `Tweet "${id}" not found` }, { status: 404 });
+    }
+    if (!tweet.isRetweeted) {
+      return HttpResponse.json({ message: 'Tweet is not retweeted.' }, { status: 400 });
+    }
+    unretweet(tweet);
+    return HttpResponse.json(
+      { success: true, message: 'Retweet undone successfully.' },
+      { status: 200 },
+    );
+  }),
+];

--- a/package.json
+++ b/package.json
@@ -1,77 +1,77 @@
 {
-    "name": "nuxt-app",
-    "type": "module",
-    "private": true,
-    "scripts": {
-        "build": "nuxt build",
-        "start": "node .output/server/index.mjs",
-        "dev": "nuxt dev",
-        "test": "vitest run",
-        "test:cov": "vitest run --coverage .",
-        "generate": "nuxt generate",
-        "preview": "nuxt preview",
-        "postinstall": "nuxt prepare",
-        "prepare": "node -e \"if (process.env.NODE_ENV !== 'production') require('child_process').execSync('husky', {stdio: 'inherit'})\"",
-        "lint": "eslint . --ext .js,.ts,.vue --fix",
-        "lint:check": "eslint . --ext .js,.ts,.vue",
-        "format": "prettier --write .",
-        "format:check": "prettier --check .",
-        "mock:gen:tweets": "tsx mocks/generators/genMockTweets.ts"
-    },
-    "dependencies": {
-        "@nuxt/eslint": "1.9.0",
-        "@nuxt/fonts": "0.11.4",
-        "@nuxt/icon": "2.0.0",
-        "@nuxt/image": "1.11.0",
-        "@nuxtjs/i18n": "10.1.0",
-        "@pinia/nuxt": "0.11.2",
-        "@tailwindcss/vite": "^4.1.14",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "nuxt": "^4.1.2",
-        "pinia": "^3.0.3",
-        "reka-ui": "^2.5.1",
-        "tailwind-merge": "^3.3.1",
-        "tailwindcss": "^4.1.14",
-        "tw-animate-css": "^1.4.0",
-        "vue": "^3.5.22",
-        "vue-router": "^4.5.1"
-    },
-    "devDependencies": {
-        "@faker-js/faker": "^9.9.0",
-        "@nuxt/test-utils": "3.19.2",
-        "@testing-library/vue": "^8.1.0",
-        "@vitest/coverage-istanbul": "^3.2.4",
-        "@vue/test-utils": "^2.4.6",
-        "@vueuse/core": "^13.9.0",
-        "@vueuse/nuxt": "^13.9.0",
-        "eslint": "^9.37.0",
-        "eslint-plugin-regex": "^1.10.0",
-        "happy-dom": "^19.0.2",
-        "husky": "^9.1.7",
-        "lint-staged": "^16.2.3",
-        "msw": "^2.11.5",
-        "playwright-core": "^1.55.1",
-        "prettier": "^3.6.2",
-        "prettier-plugin-tailwindcss": "^0.6.14",
-        "typescript": "^5.9.3",
-        "vitest": "^3.2.4"
-    },
-    "lint-staged": {
-        "*.{vue,js,jsx,ts,tsx}": [
-            "eslint --fix",
-            "prettier --write"
-        ],
-        "*.{json,md,css,scss,html}": [
-            "prettier --write"
-        ]
-    },
-    "engines": {
-        "node": ">=22.0.0"
-    },
-    "msw": {
-        "workerDirectory": [
-            "public"
-        ]
-    }
+  "name": "nuxt-app",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "nuxt build",
+    "start": "node .output/server/index.mjs",
+    "dev": "nuxt dev",
+    "test": "vitest run",
+    "test:cov": "vitest run --coverage .",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview",
+    "postinstall": "nuxt prepare",
+    "prepare": "node -e \"if (process.env.NODE_ENV !== 'production') require('child_process').execSync('husky', {stdio: 'inherit'})\"",
+    "lint": "eslint . --ext .js,.ts,.vue --fix",
+    "lint:check": "eslint . --ext .js,.ts,.vue",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "mock:gen:tweets": "tsx mocks/generators/genMockTweets.ts"
+  },
+  "dependencies": {
+    "@nuxt/eslint": "1.9.0",
+    "@nuxt/fonts": "0.11.4",
+    "@nuxt/icon": "2.0.0",
+    "@nuxt/image": "1.11.0",
+    "@nuxtjs/i18n": "10.1.0",
+    "@pinia/nuxt": "0.11.2",
+    "@tailwindcss/vite": "^4.1.14",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "nuxt": "^4.1.2",
+    "pinia": "^3.0.3",
+    "reka-ui": "^2.5.1",
+    "tailwind-merge": "^3.3.1",
+    "tailwindcss": "^4.1.14",
+    "tw-animate-css": "^1.4.0",
+    "vue": "^3.5.22",
+    "vue-router": "^4.5.1"
+  },
+  "devDependencies": {
+    "@faker-js/faker": "^9.9.0",
+    "@nuxt/test-utils": "3.19.2",
+    "@testing-library/vue": "^8.1.0",
+    "@vitest/coverage-istanbul": "^3.2.4",
+    "@vue/test-utils": "^2.4.6",
+    "@vueuse/core": "^13.9.0",
+    "@vueuse/nuxt": "^13.9.0",
+    "eslint": "^9.37.0",
+    "eslint-plugin-regex": "^1.10.0",
+    "happy-dom": "^19.0.2",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.2.3",
+    "msw": "^2.11.5",
+    "playwright-core": "^1.55.1",
+    "prettier": "^3.6.2",
+    "prettier-plugin-tailwindcss": "^0.6.14",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  },
+  "lint-staged": {
+    "*.{vue,js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,md,css,scss,html}": [
+      "prettier --write"
+    ]
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,75 +1,77 @@
 {
-  "name": "nuxt-app",
-  "type": "module",
-  "private": true,
-  "scripts": {
-    "build": "nuxt build",
-    "start": "node .output/server/index.mjs",
-    "dev": "nuxt dev",
-    "test": "vitest run",
-    "test:cov": "vitest run --coverage .",
-    "generate": "nuxt generate",
-    "preview": "nuxt preview",
-    "postinstall": "nuxt prepare",
-    "prepare": "node -e \"if (process.env.NODE_ENV !== 'production') require('child_process').execSync('husky', {stdio: 'inherit'})\"",
-    "lint": "eslint . --ext .js,.ts,.vue --fix",
-    "lint:check": "eslint . --ext .js,.ts,.vue",
-    "format": "prettier --write .",
-    "format:check": "prettier --check ."
-  },
-  "dependencies": {
-    "@nuxt/eslint": "1.9.0",
-    "@nuxt/fonts": "0.11.4",
-    "@nuxt/icon": "2.0.0",
-    "@nuxt/image": "1.11.0",
-    "@nuxtjs/i18n": "10.1.0",
-    "@pinia/nuxt": "0.11.2",
-    "@tailwindcss/vite": "^4.1.14",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "nuxt": "^4.1.2",
-    "pinia": "^3.0.3",
-    "reka-ui": "^2.5.1",
-    "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.1.14",
-    "tw-animate-css": "^1.4.0",
-    "vue": "^3.5.22",
-    "vue-router": "^4.5.1"
-  },
-  "devDependencies": {
-    "@nuxt/test-utils": "3.19.2",
-    "@testing-library/vue": "^8.1.0",
-    "@vitest/coverage-istanbul": "^3.2.4",
-    "@vue/test-utils": "^2.4.6",
-    "@vueuse/core": "^13.9.0",
-    "@vueuse/nuxt": "^13.9.0",
-    "eslint": "^9.37.0",
-    "eslint-plugin-regex": "^1.10.0",
-    "happy-dom": "^19.0.2",
-    "husky": "^9.1.7",
-    "lint-staged": "^16.2.3",
-    "msw": "^2.11.5",
-    "playwright-core": "^1.55.1",
-    "prettier": "^3.6.2",
-    "prettier-plugin-tailwindcss": "^0.6.14",
-    "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
-  },
-  "lint-staged": {
-    "*.{vue,js,jsx,ts,tsx}": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "*.{json,md,css,scss,html}": [
-      "prettier --write"
-    ]
-  },
-  "engines": {
-    "node": ">=22.0.0"
-  },
-  "msw": {
-    "workerDirectory": [
-      "public"
-    ]
-  }
+    "name": "nuxt-app",
+    "type": "module",
+    "private": true,
+    "scripts": {
+        "build": "nuxt build",
+        "start": "node .output/server/index.mjs",
+        "dev": "nuxt dev",
+        "test": "vitest run",
+        "test:cov": "vitest run --coverage .",
+        "generate": "nuxt generate",
+        "preview": "nuxt preview",
+        "postinstall": "nuxt prepare",
+        "prepare": "node -e \"if (process.env.NODE_ENV !== 'production') require('child_process').execSync('husky', {stdio: 'inherit'})\"",
+        "lint": "eslint . --ext .js,.ts,.vue --fix",
+        "lint:check": "eslint . --ext .js,.ts,.vue",
+        "format": "prettier --write .",
+        "format:check": "prettier --check .",
+        "mock:gen:tweets": "tsx mocks/generators/genMockTweets.ts"
+    },
+    "dependencies": {
+        "@nuxt/eslint": "1.9.0",
+        "@nuxt/fonts": "0.11.4",
+        "@nuxt/icon": "2.0.0",
+        "@nuxt/image": "1.11.0",
+        "@nuxtjs/i18n": "10.1.0",
+        "@pinia/nuxt": "0.11.2",
+        "@tailwindcss/vite": "^4.1.14",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "nuxt": "^4.1.2",
+        "pinia": "^3.0.3",
+        "reka-ui": "^2.5.1",
+        "tailwind-merge": "^3.3.1",
+        "tailwindcss": "^4.1.14",
+        "tw-animate-css": "^1.4.0",
+        "vue": "^3.5.22",
+        "vue-router": "^4.5.1"
+    },
+    "devDependencies": {
+        "@faker-js/faker": "^9.9.0",
+        "@nuxt/test-utils": "3.19.2",
+        "@testing-library/vue": "^8.1.0",
+        "@vitest/coverage-istanbul": "^3.2.4",
+        "@vue/test-utils": "^2.4.6",
+        "@vueuse/core": "^13.9.0",
+        "@vueuse/nuxt": "^13.9.0",
+        "eslint": "^9.37.0",
+        "eslint-plugin-regex": "^1.10.0",
+        "happy-dom": "^19.0.2",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.2.3",
+        "msw": "^2.11.5",
+        "playwright-core": "^1.55.1",
+        "prettier": "^3.6.2",
+        "prettier-plugin-tailwindcss": "^0.6.14",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+    },
+    "lint-staged": {
+        "*.{vue,js,jsx,ts,tsx}": [
+            "eslint --fix",
+            "prettier --write"
+        ],
+        "*.{json,md,css,scss,html}": [
+            "prettier --write"
+        ]
+    },
+    "engines": {
+        "node": ">=22.0.0"
+    },
+    "msw": {
+        "workerDirectory": [
+            "public"
+        ]
+    }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "playwright-core": "^1.55.1",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
+    "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ importers:
     dependencies:
       '@nuxt/eslint':
         specifier: 1.9.0
-        version: 1.9.0(@typescript-eslint/utils@8.45.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.22)(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))(magicast@0.3.5)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+        version: 1.9.0(@typescript-eslint/utils@8.45.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.22)(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))(magicast@0.3.5)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@nuxt/fonts':
         specifier: 0.11.4
-        version: 0.11.4(db0@0.3.4)(ioredis@5.8.0)(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+        version: 0.11.4(db0@0.3.4)(ioredis@5.8.0)(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@nuxt/icon':
         specifier: 2.0.0
-        version: 2.0.0(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
+        version: 2.0.0(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
       '@nuxt/image':
         specifier: 1.11.0
         version: 1.11.0(db0@0.3.4)(ioredis@5.8.0)(magicast@0.3.5)
@@ -28,7 +28,7 @@ importers:
         version: 0.11.2(magicast@0.3.5)(pinia@3.0.3(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3)))
       '@tailwindcss/vite':
         specifier: ^4.1.14
-        version: 4.1.14(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+        version: 4.1.14(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -37,7 +37,7 @@ importers:
         version: 2.1.1
       nuxt:
         specifier: ^4.1.2
-        version: 4.1.2(@parcel/watcher@2.5.1)(@types/node@20.19.19)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
+        version: 4.1.2(@parcel/watcher@2.5.1)(@types/node@20.19.19)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       pinia:
         specifier: ^3.0.3
         version: 3.0.3(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))
@@ -65,13 +65,13 @@ importers:
         version: 9.9.0
       '@nuxt/test-utils':
         specifier: 3.19.2
-        version: 3.19.2(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1))
+        version: 3.19.2(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@testing-library/vue':
         specifier: ^8.1.0
         version: 8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3))
       '@vitest/coverage-istanbul':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1))
+        version: 3.2.4(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6
@@ -80,7 +80,7 @@ importers:
         version: 13.9.0(vue@3.5.22(typescript@5.9.3))
       '@vueuse/nuxt':
         specifier: ^13.9.0
-        version: 13.9.0(magicast@0.3.5)(nuxt@4.1.2(@parcel/watcher@2.5.1)(@types/node@20.19.19)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
+        version: 13.9.0(magicast@0.3.5)(nuxt@4.1.2(@parcel/watcher@2.5.1)(@types/node@20.19.19)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
       eslint:
         specifier: ^9.37.0
         version: 9.37.0(jiti@2.6.1)
@@ -108,12 +108,15 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
         version: 0.6.14(prettier@3.6.2)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1)
+        version: 3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
 packages:
 
@@ -5104,6 +5107,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.20.6:
+    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -6323,11 +6331,11 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@2.6.5(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@nuxt/devtools-kit@2.6.5(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@nuxt/kit': 3.19.2(magicast@0.3.5)
       execa: 8.0.1
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - magicast
 
@@ -6342,12 +6350,12 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.2
 
-  '@nuxt/devtools@2.6.5(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
+  '@nuxt/devtools@2.6.5(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
-      '@nuxt/devtools-kit': 2.6.5(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      '@nuxt/devtools-kit': 2.6.5(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@nuxt/devtools-wizard': 2.6.5
       '@nuxt/kit': 3.19.2(magicast@0.3.5)
-      '@vue/devtools-core': 7.7.7(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
+      '@vue/devtools-core': 7.7.7(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
       '@vue/devtools-kit': 7.7.7
       birpc: 2.6.1
       consola: 3.4.2
@@ -6372,9 +6380,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.19.2(magicast@0.3.5))(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
-      vite-plugin-vue-tracer: 1.0.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.19.2(magicast@0.3.5))(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      vite-plugin-vue-tracer: 1.0.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
       which: 5.0.0
       ws: 8.18.3
     transitivePeerDependencies:
@@ -6423,10 +6431,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.9.0(@typescript-eslint/utils@8.45.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.22)(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))(magicast@0.3.5)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@nuxt/eslint@1.9.0(@typescript-eslint/utils@8.45.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.22)(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))(magicast@0.3.5)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@eslint/config-inspector': 1.3.0(eslint@9.37.0(jiti@2.6.1))
-      '@nuxt/devtools-kit': 2.6.5(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      '@nuxt/devtools-kit': 2.6.5(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@nuxt/eslint-config': 1.9.0(@typescript-eslint/utils@8.45.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.22)(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/eslint-plugin': 1.9.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/kit': 4.1.2(magicast@0.3.5)
@@ -6451,9 +6459,9 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@nuxt/fonts@0.11.4(db0@0.3.4)(ioredis@5.8.0)(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@nuxt/fonts@0.11.4(db0@0.3.4)(ioredis@5.8.0)(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
-      '@nuxt/devtools-kit': 2.6.5(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      '@nuxt/devtools-kit': 2.6.5(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@nuxt/kit': 3.19.2(magicast@0.3.5)
       consola: 3.4.2
       css-tree: 3.1.0
@@ -6497,13 +6505,13 @@ snapshots:
       - uploadthing
       - vite
 
-  '@nuxt/icon@2.0.0(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
+  '@nuxt/icon@2.0.0(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@iconify/collections': 1.0.601
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.0.2
       '@iconify/vue': 5.0.0(vue@3.5.22(typescript@5.9.3))
-      '@nuxt/devtools-kit': 2.6.5(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      '@nuxt/devtools-kit': 2.6.5(magicast@0.3.5)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@nuxt/kit': 4.1.2(magicast@0.3.5)
       consola: 3.4.2
       local-pkg: 1.1.2
@@ -6639,7 +6647,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/test-utils@3.19.2(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1))':
+  '@nuxt/test-utils@3.19.2(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@nuxt/kit': 3.19.2(magicast@0.3.5)
       c12: 3.3.0(magicast@0.3.5)
@@ -6663,24 +6671,24 @@ snapshots:
       tinyexec: 1.0.1
       ufo: 1.6.1
       unplugin: 2.3.10
-      vitest-environment-nuxt: 1.0.1(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1))
+      vitest-environment-nuxt: 1.0.1(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       vue: 3.5.22(typescript@5.9.3)
     optionalDependencies:
       '@testing-library/vue': 8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3))
       '@vue/test-utils': 2.4.6
       happy-dom: 19.0.2
       playwright-core: 1.55.1
-      vitest: 3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - magicast
       - typescript
 
-  '@nuxt/vite-builder@4.1.2(@types/node@20.19.19)(eslint@9.37.0(jiti@2.6.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))(yaml@2.8.1)':
+  '@nuxt/vite-builder@4.1.2(@types/node@20.19.19)(eslint@9.37.0(jiti@2.6.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.52.4)
-      '@vitejs/plugin-vue': 6.0.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
       autoprefixer: 10.4.21(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.1(postcss@8.5.6)
@@ -6702,9 +6710,9 @@ snapshots:
       std-env: 3.9.0
       ufo: 1.6.1
       unenv: 2.0.0-rc.21
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-plugin-checker: 0.10.3(eslint@9.37.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-plugin-checker: 0.10.3(eslint@9.37.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       vue: 3.5.22(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     transitivePeerDependencies:
@@ -7355,12 +7363,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.14
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.14
 
-  '@tailwindcss/vite@4.1.14(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@tailwindcss/vite@4.1.14(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.1.14
       '@tailwindcss/oxide': 4.1.14
       tailwindcss: 4.1.14
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@tanstack/virtual-core@3.13.12': {}
 
@@ -7602,25 +7610,25 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
       '@rolldown/pluginutils': 1.0.0-beta.41
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       vue: 3.5.22(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       vue: 3.5.22(typescript@5.9.3)
 
-  '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1))':
+  '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.4.3
@@ -7632,7 +7640,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7644,14 +7652,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
       msw: 2.11.5(@types/node@20.19.19)(typescript@5.9.3)
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7770,14 +7778,14 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.7.7
 
-  '@vue/devtools-core@7.7.7(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
+  '@vue/devtools-core@7.7.7(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
       mitt: 3.0.1
       nanoid: 5.1.6
       pathe: 2.0.3
-      vite-hot-client: 2.1.0(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      vite-hot-client: 2.1.0(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       vue: 3.5.22(typescript@5.9.3)
     transitivePeerDependencies:
       - vite
@@ -7857,13 +7865,13 @@ snapshots:
 
   '@vueuse/metadata@13.9.0': {}
 
-  '@vueuse/nuxt@13.9.0(magicast@0.3.5)(nuxt@4.1.2(@parcel/watcher@2.5.1)(@types/node@20.19.19)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
+  '@vueuse/nuxt@13.9.0(magicast@0.3.5)(nuxt@4.1.2(@parcel/watcher@2.5.1)(@types/node@20.19.19)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@nuxt/kit': 3.19.2(magicast@0.3.5)
       '@vueuse/core': 13.9.0(vue@3.5.22(typescript@5.9.3))
       '@vueuse/metadata': 13.9.0
       local-pkg: 1.1.2
-      nuxt: 4.1.2(@parcel/watcher@2.5.1)(@types/node@20.19.19)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
+      nuxt: 4.1.2(@parcel/watcher@2.5.1)(@types/node@20.19.19)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       vue: 3.5.22(typescript@5.9.3)
     transitivePeerDependencies:
       - magicast
@@ -9952,15 +9960,15 @@ snapshots:
 
   nuxt-define@1.0.0: {}
 
-  nuxt@4.1.2(@parcel/watcher@2.5.1)(@types/node@20.19.19)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1):
+  nuxt@4.1.2(@parcel/watcher@2.5.1)(@types/node@20.19.19)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1):
     dependencies:
       '@nuxt/cli': 3.28.0(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.6.5(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
+      '@nuxt/devtools': 2.6.5(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
       '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@nuxt/schema': 4.1.2
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 4.1.2(@types/node@20.19.19)(eslint@9.37.0(jiti@2.6.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))(yaml@2.8.1)
+      '@nuxt/vite-builder': 4.1.2(@types/node@20.19.19)(eslint@9.37.0(jiti@2.6.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))(yaml@2.8.1)
       '@unhead/vue': 2.0.17(vue@3.5.22(typescript@5.9.3))
       '@vue/shared': 3.5.22
       c12: 3.3.0(magicast@0.3.5)
@@ -11195,6 +11203,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.20.6:
+    dependencies:
+      esbuild: 0.25.10
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -11416,23 +11431,23 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-dev-rpc@1.1.0(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)):
+  vite-dev-rpc@1.1.0(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       birpc: 2.6.1
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-hot-client: 2.1.0(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-hot-client: 2.1.0(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
 
-  vite-hot-client@2.1.0(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)):
+  vite-hot-client@2.1.0(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
-  vite-node@3.2.4(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -11447,7 +11462,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.10.3(eslint@9.37.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)):
+  vite-plugin-checker@0.10.3(eslint@9.37.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chokidar: 4.0.3
@@ -11457,14 +11472,14 @@ snapshots:
       strip-ansi: 7.1.2
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.15
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 9.37.0(jiti@2.6.1)
       optionator: 0.9.4
       typescript: 5.9.3
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@3.19.2(magicast@0.3.5))(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@3.19.2(magicast@0.3.5))(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -11474,24 +11489,24 @@ snapshots:
       perfect-debounce: 2.0.0
       sirv: 3.0.2
       unplugin-utils: 0.3.0
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-dev-rpc: 1.1.0(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-dev-rpc: 1.1.0(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
     optionalDependencies:
       '@nuxt/kit': 3.19.2(magicast@0.3.5)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.0.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3)):
+  vite-plugin-vue-tracer@1.0.1(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.7
       magic-string: 0.30.19
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       vue: 3.5.22(typescript@5.9.3)
 
-  vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1):
+  vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -11505,11 +11520,12 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.1
       terser: 5.44.0
+      tsx: 4.20.6
       yaml: 2.8.1
 
-  vitest-environment-nuxt@1.0.1(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1)):
+  vitest-environment-nuxt@1.0.1(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
-      '@nuxt/test-utils': 3.19.2(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1))
+      '@nuxt/test-utils': 3.19.2(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -11524,11 +11540,11 @@ snapshots:
       - typescript
       - vitest
 
-  vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1):
+  vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(vite@7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -11546,8 +11562,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.9(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.19

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,10 @@ packages:
     resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@faker-js/faker@9.9.0':
+    resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
+
   '@fastify/accept-negotiator@1.1.0':
     resolution: {integrity: sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ==}
     engines: {node: '>=14'}
@@ -6003,6 +6007,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.16.0
       levn: 0.4.1
+
+  '@faker-js/faker@9.9.0': {}
 
   '@fastify/accept-negotiator@1.1.0':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
         specifier: ^4.5.1
         version: 4.5.1(vue@3.5.22(typescript@5.9.3))
     devDependencies:
+      '@faker-js/faker':
+        specifier: ^9.9.0
+        version: 9.9.0
       '@nuxt/test-utils':
         specifier: 3.19.2
         version: 3.19.2(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.22)(vue@3.5.22(typescript@5.9.3)))(@vue/test-utils@2.4.6)(happy-dom@19.0.2)(magicast@0.3.5)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.4(@types/node@20.19.19)(happy-dom@19.0.2)(jiti@2.6.1)(lightningcss@1.30.1)(msw@2.11.5(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1))

--- a/server/api/tweets/[id]/index.get.ts
+++ b/server/api/tweets/[id]/index.get.ts
@@ -1,0 +1,30 @@
+import { FetchError } from 'ofetch';
+import type { Tweet } from '~~/types/tweets';
+
+interface ApiError {
+  message: string;
+}
+
+const API_URL = process.env.BACKEND_URL;
+
+export default defineEventHandler(async (event) => {
+  const { id } = event.context.params as { id: string };
+  try {
+    const tweet = await $fetch<Tweet>(`${API_URL}/tweets/${id}`);
+    return tweet;
+  } catch (e) {
+    if (e instanceof FetchError) {
+      const errData = e.data as ApiError;
+      throw createError({
+        message: errData?.message || 'Request failed',
+        statusCode: e.statusCode || 500,
+      });
+    }
+
+    // Generic error fallback
+    throw createError({
+      message: 'An unexpected error occurred',
+      statusCode: 500,
+    });
+  }
+});

--- a/server/api/tweets/[id]/like/index.delete.ts
+++ b/server/api/tweets/[id]/like/index.delete.ts
@@ -1,0 +1,35 @@
+import { FetchError } from 'ofetch';
+
+interface ApiError {
+  message: string;
+}
+
+const API_URL = process.env.BACKEND_URL;
+
+export default defineEventHandler(async (event) => {
+  const { id } = event.context.params as { id: string };
+  try {
+    // Forward the request to your backend API
+    const response = await $fetch<{
+      success: boolean;
+      message: string;
+    }>(`${API_URL}/tweets/${id}/like`, {
+      method: 'DELETE',
+    });
+
+    return response;
+  } catch (e) {
+    if (e instanceof FetchError) {
+      const errData = e.data as ApiError;
+      throw createError({
+        message: errData?.message || 'Failed to create tweet',
+        statusCode: e.statusCode || 500,
+      });
+    }
+
+    throw createError({
+      message: 'Unexpected error creating tweet',
+      statusCode: 500,
+    });
+  }
+});

--- a/server/api/tweets/[id]/like/index.post.ts
+++ b/server/api/tweets/[id]/like/index.post.ts
@@ -1,0 +1,35 @@
+import { FetchError } from 'ofetch';
+
+interface ApiError {
+  message: string;
+}
+
+const API_URL = process.env.BACKEND_URL;
+
+export default defineEventHandler(async (event) => {
+  const { id } = event.context.params as { id: string };
+  try {
+    // Forward the request to your backend API
+    const response = await $fetch<{
+      success: boolean;
+      message: string;
+    }>(`${API_URL}/tweets/${id}/like`, {
+      method: 'POST',
+    });
+
+    return response;
+  } catch (e) {
+    if (e instanceof FetchError) {
+      const errData = e.data as ApiError;
+      throw createError({
+        message: errData?.message || 'Failed to create tweet',
+        statusCode: e.statusCode || 500,
+      });
+    }
+
+    throw createError({
+      message: 'Unexpected error creating tweet',
+      statusCode: 500,
+    });
+  }
+});

--- a/server/api/tweets/[id]/retweet/index.delete.ts
+++ b/server/api/tweets/[id]/retweet/index.delete.ts
@@ -1,0 +1,35 @@
+import { FetchError } from 'ofetch';
+
+interface ApiError {
+  message: string;
+}
+
+const API_URL = process.env.BACKEND_URL;
+
+export default defineEventHandler(async (event) => {
+  const { id } = event.context.params as { id: string };
+  try {
+    // Forward the request to your backend API
+    const response = await $fetch<{
+      success: boolean;
+      message: string;
+    }>(`${API_URL}/tweets/${id}/retweet`, {
+      method: 'DELETE',
+    });
+
+    return response;
+  } catch (e) {
+    if (e instanceof FetchError) {
+      const errData = e.data as ApiError;
+      throw createError({
+        message: errData?.message || 'Failed to create tweet',
+        statusCode: e.statusCode || 500,
+      });
+    }
+
+    throw createError({
+      message: 'Unexpected error creating tweet',
+      statusCode: 500,
+    });
+  }
+});

--- a/server/api/tweets/[id]/retweet/index.post.ts
+++ b/server/api/tweets/[id]/retweet/index.post.ts
@@ -1,0 +1,35 @@
+import { FetchError } from 'ofetch';
+
+interface ApiError {
+  message: string;
+}
+
+const API_URL = process.env.BACKEND_URL;
+
+export default defineEventHandler(async (event) => {
+  const { id } = event.context.params as { id: string };
+  try {
+    // Forward the request to your backend API
+    const response = await $fetch<{
+      success: boolean;
+      message: string;
+    }>(`${API_URL}/tweets/${id}/retweet`, {
+      method: 'POST',
+    });
+
+    return response;
+  } catch (e) {
+    if (e instanceof FetchError) {
+      const errData = e.data as ApiError;
+      throw createError({
+        message: errData?.message || 'Failed to create tweet',
+        statusCode: e.statusCode || 500,
+      });
+    }
+
+    throw createError({
+      message: 'Unexpected error creating tweet',
+      statusCode: 500,
+    });
+  }
+});

--- a/server/api/tweets/index.get.ts
+++ b/server/api/tweets/index.get.ts
@@ -1,0 +1,29 @@
+import { FetchError } from 'ofetch';
+import type { Tweet } from '~~/types/tweets';
+
+interface ApiError {
+  message: string;
+}
+
+const API_URL = process.env.BACKEND_URL;
+
+export default defineEventHandler(async () => {
+  try {
+    const tweets = await $fetch<Tweet[]>(`${API_URL}/tweets`);
+    return tweets;
+  } catch (e) {
+    if (e instanceof FetchError) {
+      const errData = e.data as ApiError;
+      throw createError({
+        message: errData?.message || 'Request failed',
+        statusCode: e.statusCode || 500,
+      });
+    }
+
+    // Generic error fallback
+    throw createError({
+      message: 'An unexpected error occurred',
+      statusCode: 500,
+    });
+  }
+});

--- a/test/unit/api/tweets/api.spec.ts
+++ b/test/unit/api/tweets/api.spec.ts
@@ -1,0 +1,483 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// We will mock Nitro/NUXT server globals and ofetch's FetchError, then dynamically import handlers
+// so the mocks are in place before module evaluation.
+
+// Mock ofetch's FetchError class used inside handlers for instanceof checks
+vi.mock('ofetch', () => {
+  class MockFetchError extends Error {
+    data?: unknown;
+    statusCode?: number;
+    constructor(message: string, data?: unknown, statusCode?: number) {
+      super(message);
+      this.name = 'FetchError';
+      this.data = data;
+      this.statusCode = statusCode;
+    }
+  }
+  return { FetchError: MockFetchError };
+});
+
+// Utility: create a minimal H3/Nitro event with params
+const makeEvent = (params: Record<string, string> = {}) => ({
+  context: { params },
+});
+
+declare global {
+  var defineEventHandler: <T extends (...args: unknown[]) => unknown>(handler: T) => T;
+  var createError: (input: {
+    message: string;
+    statusCode?: number;
+  }) => Error & { statusCode?: number };
+  var $fetch: ReturnType<typeof vi.fn>;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  // Ensure a clean module graph between tests so imports re-evaluate with our stubs
+  vi.resetModules();
+
+  // Stub Nitro helpers
+  // defineEventHandler should just return the handler function
+  const defEH = ((fn: (...args: unknown[]) => unknown) => fn) as unknown;
+  vi.stubGlobal('defineEventHandler', defEH);
+  // createError should create an Error with statusCode
+  vi.stubGlobal(
+    'createError',
+    ({ message, statusCode }: { message: string; statusCode?: number }) => {
+      const err = new Error(message) as Error & { statusCode?: number };
+      err.name = 'HTTPError';
+      err.statusCode = statusCode;
+      return err;
+    },
+  );
+
+  // Stub $fetch globally
+  fetchMock = vi.fn();
+  vi.stubGlobal('$fetch', fetchMock as unknown);
+
+  // Provide backend URL
+  process.env.BACKEND_URL = 'https://api.example.com';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Server API - Tweets', () => {
+  describe('GET /api/tweets', () => {
+    it('returns list of tweets on success', async () => {
+      const sampleTweets = [
+        {
+          id: '1',
+          content: 'Hello world',
+          createdAt: new Date().toISOString(),
+          author: {
+            username: 'john',
+            displayName: 'John',
+            avatarUrl: 'x',
+            isFollowing: false,
+            isFollower: false,
+          },
+          replyCount: 0,
+          retweetCount: 0,
+          likeCount: 0,
+          isLiked: false,
+          isRetweeted: false,
+          entities: { mentions: [], hashtags: [] },
+          media: [],
+        },
+      ];
+
+      fetchMock.mockResolvedValueOnce(sampleTweets);
+      const handler = (await import('../../../../server/api/tweets/index.get')).default;
+      const result = await handler();
+
+      expect(fetchMock).toHaveBeenCalledWith('https://api.example.com/tweets');
+      expect(result).toEqual(sampleTweets);
+    });
+
+    it('maps FetchError to HTTP error with backend message and status code', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Fail', { message: 'Backend down' }, 503),
+      );
+
+      const handler = (await import('../../../../server/api/tweets/index.get')).default;
+
+      await expect(handler()).rejects.toMatchObject({ message: 'Backend down', statusCode: 503 });
+    });
+
+    it("uses default 'Request failed' when FetchError has no message", async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      // No data/message provided to force default message path
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Fail', undefined, 502),
+      );
+      const handler = (await import('../../../../server/api/tweets/index.get')).default;
+      await expect(handler()).rejects.toMatchObject({ message: 'Request failed', statusCode: 502 });
+    });
+
+    it('defaults statusCode to 500 when missing in FetchError', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      // Provide a message but omit status to hit e.statusCode || 500
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Fail', { message: 'Backend msg' }),
+      );
+      const handler = (await import('../../../../server/api/tweets/index.get')).default;
+      await expect(handler()).rejects.toMatchObject({ message: 'Backend msg', statusCode: 500 });
+    });
+
+    it('maps unknown errors to 500 with generic message', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Boom'));
+      const handler = (await import('../../../../server/api/tweets/index.get')).default;
+      await expect(handler()).rejects.toMatchObject({
+        message: 'An unexpected error occurred',
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe('GET /api/tweets/:id', () => {
+    it('returns a tweet by id', async () => {
+      const tweetId = '42';
+      const sampleTweet = {
+        id: tweetId,
+        content: 'The answer',
+        createdAt: new Date().toISOString(),
+        author: {
+          username: 'arthur',
+          displayName: 'Arthur',
+          avatarUrl: 'x',
+          isFollowing: false,
+          isFollower: false,
+        },
+        replyCount: 0,
+        retweetCount: 0,
+        likeCount: 0,
+        isLiked: false,
+        isRetweeted: false,
+        entities: { mentions: [], hashtags: [] },
+        media: [],
+      };
+
+      fetchMock.mockResolvedValueOnce(sampleTweet);
+      const handler = (await import('../../../../server/api/tweets/[id]/index.get')).default;
+      const result = await handler(makeEvent({ id: tweetId }));
+
+      expect(fetchMock).toHaveBeenCalledWith(`https://api.example.com/tweets/${tweetId}`);
+      expect(result).toEqual(sampleTweet);
+    });
+
+    it('maps FetchError to HTTP error', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Nope', { message: 'Not found' }, 404),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/index.get')).default;
+      await expect(handler(makeEvent({ id: '999' }))).rejects.toMatchObject({
+        message: 'Not found',
+        statusCode: 404,
+      });
+    });
+
+    it("uses default 'Request failed' when FetchError has no message", async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Fail', undefined, 500),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/index.get')).default;
+      await expect(handler(makeEvent({ id: '123' }))).rejects.toMatchObject({
+        message: 'Request failed',
+        statusCode: 500,
+      });
+    });
+
+    it('defaults statusCode to 500 when missing in FetchError', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Fail', { message: 'By id msg' }),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/index.get')).default;
+      await expect(handler(makeEvent({ id: '123' }))).rejects.toMatchObject({
+        message: 'By id msg',
+        statusCode: 500,
+      });
+    });
+
+    it('maps unknown errors to 500', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Oops'));
+      const handler = (await import('../../../../server/api/tweets/[id]/index.get')).default;
+      await expect(handler(makeEvent({ id: '1' }))).rejects.toMatchObject({
+        message: 'An unexpected error occurred',
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe('POST /api/tweets/:id/like', () => {
+    it('forwards like to backend and returns response', async () => {
+      fetchMock.mockResolvedValueOnce({ success: true, message: 'Liked' });
+      const handler = (await import('../../../../server/api/tweets/[id]/like/index.post')).default;
+      const res = await handler(makeEvent({ id: '7' }));
+
+      expect(fetchMock).toHaveBeenCalledWith('https://api.example.com/tweets/7/like', {
+        method: 'POST',
+      });
+      expect(res).toEqual({ success: true, message: 'Liked' });
+    });
+
+    it('maps FetchError to HTTP error with fallback message', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', undefined, 400),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/like/index.post')).default;
+      await expect(handler(makeEvent({ id: '7' }))).rejects.toMatchObject({
+        message: 'Failed to create tweet',
+        statusCode: 400,
+      });
+    });
+
+    it('maps FetchError to HTTP error using backend message', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', { message: 'Already liked' }, 409),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/like/index.post')).default;
+      await expect(handler(makeEvent({ id: '7' }))).rejects.toMatchObject({
+        message: 'Already liked',
+        statusCode: 409,
+      });
+    });
+
+    it('defaults statusCode to 500 when missing in FetchError', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', { message: 'Like failed' }),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/like/index.post')).default;
+      await expect(handler(makeEvent({ id: '7' }))).rejects.toMatchObject({
+        message: 'Like failed',
+        statusCode: 500,
+      });
+    });
+
+    it('maps unknown errors to 500 with unexpected message', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Down'));
+      const handler = (await import('../../../../server/api/tweets/[id]/like/index.post')).default;
+      await expect(handler(makeEvent({ id: '7' }))).rejects.toMatchObject({
+        message: 'Unexpected error creating tweet',
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe('DELETE /api/tweets/:id/like', () => {
+    it('forwards unlike to backend and returns response', async () => {
+      fetchMock.mockResolvedValueOnce({ success: true, message: 'Unliked' });
+      const handler = (await import('../../../../server/api/tweets/[id]/like/index.delete'))
+        .default;
+      const res = await handler(makeEvent({ id: '8' }));
+
+      expect(fetchMock).toHaveBeenCalledWith('https://api.example.com/tweets/8/like', {
+        method: 'DELETE',
+      });
+      expect(res).toEqual({ success: true, message: 'Unliked' });
+    });
+
+    it('maps FetchError to HTTP error with fallback message', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', undefined, 400),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/like/index.delete'))
+        .default;
+      await expect(handler(makeEvent({ id: '8' }))).rejects.toMatchObject({
+        message: 'Failed to create tweet',
+        statusCode: 400,
+      });
+    });
+
+    it('maps FetchError to HTTP error using backend message', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', { message: 'Not liked' }, 409),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/like/index.delete'))
+        .default;
+      await expect(handler(makeEvent({ id: '8' }))).rejects.toMatchObject({
+        message: 'Not liked',
+        statusCode: 409,
+      });
+    });
+
+    it('defaults statusCode to 500 when missing in FetchError', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', { message: 'Unlike failed' }),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/like/index.delete'))
+        .default;
+      await expect(handler(makeEvent({ id: '8' }))).rejects.toMatchObject({
+        message: 'Unlike failed',
+        statusCode: 500,
+      });
+    });
+
+    it('maps unknown errors to 500 with unexpected message', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Down'));
+      const handler = (await import('../../../../server/api/tweets/[id]/like/index.delete'))
+        .default;
+      await expect(handler(makeEvent({ id: '8' }))).rejects.toMatchObject({
+        message: 'Unexpected error creating tweet',
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe('POST /api/tweets/:id/retweet', () => {
+    it('forwards retweet to backend and returns response', async () => {
+      fetchMock.mockResolvedValueOnce({ success: true, message: 'Retweeted' });
+      const handler = (await import('../../../../server/api/tweets/[id]/retweet/index.post'))
+        .default;
+      const res = await handler(makeEvent({ id: '9' }));
+
+      expect(fetchMock).toHaveBeenCalledWith('https://api.example.com/tweets/9/retweet', {
+        method: 'POST',
+      });
+      expect(res).toEqual({ success: true, message: 'Retweeted' });
+    });
+
+    it('maps FetchError to HTTP error with fallback message', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', undefined, 400),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/retweet/index.post'))
+        .default;
+      await expect(handler(makeEvent({ id: '9' }))).rejects.toMatchObject({
+        message: 'Failed to create tweet',
+        statusCode: 400,
+      });
+    });
+
+    it('maps FetchError to HTTP error using backend message', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', { message: 'Already retweeted' }, 409),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/retweet/index.post'))
+        .default;
+      await expect(handler(makeEvent({ id: '9' }))).rejects.toMatchObject({
+        message: 'Already retweeted',
+        statusCode: 409,
+      });
+    });
+
+    it('defaults statusCode to 500 when missing in FetchError', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', { message: 'Retweet failed' }),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/retweet/index.post'))
+        .default;
+      await expect(handler(makeEvent({ id: '9' }))).rejects.toMatchObject({
+        message: 'Retweet failed',
+        statusCode: 500,
+      });
+    });
+
+    it('maps unknown errors to 500 with unexpected message', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Down'));
+      const handler = (await import('../../../../server/api/tweets/[id]/retweet/index.post'))
+        .default;
+      await expect(handler(makeEvent({ id: '9' }))).rejects.toMatchObject({
+        message: 'Unexpected error creating tweet',
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe('DELETE /api/tweets/:id/retweet', () => {
+    it('forwards unretweet to backend and returns response', async () => {
+      fetchMock.mockResolvedValueOnce({ success: true, message: 'Unretweeted' });
+      const handler = (await import('../../../../server/api/tweets/[id]/retweet/index.delete'))
+        .default;
+      const res = await handler(makeEvent({ id: '10' }));
+
+      expect(fetchMock).toHaveBeenCalledWith('https://api.example.com/tweets/10/retweet', {
+        method: 'DELETE',
+      });
+      expect(res).toEqual({ success: true, message: 'Unretweeted' });
+    });
+
+    it('maps FetchError to HTTP error with fallback message', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', undefined, 400),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/retweet/index.delete'))
+        .default;
+      await expect(handler(makeEvent({ id: '10' }))).rejects.toMatchObject({
+        message: 'Failed to create tweet',
+        statusCode: 400,
+      });
+    });
+
+    it('maps FetchError to HTTP error using backend message', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', { message: 'Not retweeted' }, 409),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/retweet/index.delete'))
+        .default;
+      await expect(handler(makeEvent({ id: '10' }))).rejects.toMatchObject({
+        message: 'Not retweeted',
+        statusCode: 409,
+      });
+    });
+
+    it('defaults statusCode to 500 when missing in FetchError', async () => {
+      const { FetchError } = await import('ofetch');
+      type FetchErrorCtor = new (message: string, data?: unknown, statusCode?: number) => unknown;
+      fetchMock.mockRejectedValueOnce(
+        new (FetchError as unknown as FetchErrorCtor)('Bad', { message: 'Unretweet failed' }),
+      );
+      const handler = (await import('../../../../server/api/tweets/[id]/retweet/index.delete'))
+        .default;
+      await expect(handler(makeEvent({ id: '10' }))).rejects.toMatchObject({
+        message: 'Unretweet failed',
+        statusCode: 500,
+      });
+    });
+
+    it('maps unknown errors to 500 with unexpected message', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Down'));
+      const handler = (await import('../../../../server/api/tweets/[id]/retweet/index.delete'))
+        .default;
+      await expect(handler(makeEvent({ id: '10' }))).rejects.toMatchObject({
+        message: 'Unexpected error creating tweet',
+        statusCode: 500,
+      });
+    });
+  });
+});

--- a/types/tweets.ts
+++ b/types/tweets.ts
@@ -1,0 +1,44 @@
+type TweetAuthor = {
+  username: string;
+  displayName: string;
+  avatarUrl: string;
+  isFollowing: boolean;
+  isFollower: boolean;
+};
+
+type TweetMention = {
+  username: string;
+  startPosition: number;
+};
+type TweetHashtag = {
+  hashtag: string;
+  startPosition: number;
+};
+type TweetMedia = {
+  type: 'IMAGE' | 'VIDEO' | 'GIF';
+  url: string;
+  altText: string;
+  width: number;
+  height: number;
+};
+
+type TweetEntity = {
+  mentions: TweetMention[];
+  hashtags: TweetHashtag[];
+};
+export type Tweet = {
+  id: string;
+  content: string;
+  createdAt: string;
+  author: TweetAuthor;
+  replyCount: number;
+  retweetCount: number;
+  likeCount: number;
+  isLiked: boolean;
+  isRetweeted: boolean;
+  entities: TweetEntity;
+  media: TweetMedia[];
+  isReplyToTweetId?: string;
+  quotedTweetId?: string;
+  quotedTweet?: Tweet;
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
       provider: 'istanbul',
       reporter: ['text', 'json', 'lcov'],
       reportsDirectory: './coverage',
-      include: ['app/**'],
-      exclude: ['**/pages/playground/**'],
+      include: ['app/**', 'server/**'],
+      exclude: ['**/pages/playground/**', '**/plugins/**'],
     },
     projects: [
       {


### PR DESCRIPTION
This pull request introduces a mock API and supporting infrastructure for tweet-related features, including mock data generation, tweet handlers, and server API endpoints. It also adds internationalization for tweet-not-found messages and updates dependencies to support these new features. The main goal is to enable frontend development and testing of tweet functionality without relying on a live backend.

**Mock API and Data Generation:**

* Added a mock tweet data generator using `@faker-js/faker` to create realistic tweet objects and save them to `mocks/data/tweet.json`. [[1]](diffhunk://#diff-bff1abfd4722405b33716b7eaf66bc04ed4d9d22b3d5a96e0d6e701c8540de21R1-R103) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R41) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR63-R65) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R19)
* Implemented mock API handlers in `mocks/handlers/tweet.ts` for fetching tweets, liking/unliking, and retweeting/unretweeting, with full in-memory state management. [[1]](diffhunk://#diff-2d2f55ef8eded96d5ddc9309b32c2341312492ea62d4c516754041b61622fff9R1-R136) [[2]](diffhunk://#diff-41d8d054851682b9098c6c1af228b9792e71db7c72cefec4ad0e2f24dbba4294R2-R7)

**Server API Endpoints:**

* Added server endpoints under `server/api/tweets` for fetching all tweets, fetching by ID, liking/unliking, and retweeting/unretweeting, each forwarding requests to the mock backend and handling errors gracefully. ([server/api/tweets/index.get.tsR1-R29](diffhunk://#diff-5cd1d044742f922a5ff8e369fe0d1bf842dbb653716a0c81dd400cd8214650dcR1-R29), [server/api/tweets/[id]/index.get.tsR1-R30](diffhunk://#diff-313bde6be4ead42f6cb4361d393e3cd92d588b9c12e88c1db0d949b425f1f407R1-R30), [server/api/tweets/[id]/like/index.post.tsR1-R35](diffhunk://#diff-efdc928b988a128a553d8bafc7a7e480ad955b5247d104076f6399c1ddfed9a3R1-R35), [server/api/tweets/[id]/like/index.delete.tsR1-R35](diffhunk://#diff-c9104fa7b14e60422c1815f3b15326b2fe5353fadfa5efde0a977cf8ea1c83dcR1-R35), [server/api/tweets/[id]/retweet/index.post.tsR1-R35](diffhunk://#diff-a93fc2987d2050c42f1371d4db4928ac1724c3c31dbe2e7e0ad4b8499567f70aR1-R35), [server/api/tweets/[id]/retweet/index.delete.tsR1-R35](diffhunk://#diff-c30fcf89931c0dab66c3d07b5dbbe04e06ad7b106cdcaf1cdf0cd01cf3ead79dR1-R35))

**Frontend Integration:**

* Updated the playground tweet page to fetch tweets from the new API and display a tweet or a not-found message using i18n.

**Internationalization:**

* Added `tweet-not-found` message to both English and Arabic locale files for improved user feedback. [[1]](diffhunk://#diff-4c5e948ebdf8601f1013d7979d2e623707d40bb142d1889d5666473f15f6fd5dR13-R15) [[2]](diffhunk://#diff-43797997749f8d496813c16080f24f835b197d11f499217e9fadddb2b1c5becdL13-R16)

**Type Definitions and Test Coverage:**

* Defined comprehensive tweet-related types in `types/tweets.ts` for consistent data modeling.
* Expanded test coverage to include server files in `vitest.config.ts`.This pull request introduces a comprehensive mock API and supporting data for tweet-related features in the project. It adds a new tweet data model, generates mock tweet data, and provides MSW (Mock Service Worker) handlers for tweet fetching, liking, unliking, retweeting, and undoing retweets. Additionally, it updates dependencies and scripts to support these new features.

**Mock tweet API and data infrastructure:**

* Introduced a new `Tweet` type and related types (`TweetAuthor`, `TweetMention`, `TweetHashtag`, `TweetMedia`, `TweetEntity`) in `types/tweets.ts` to define the tweet data structure.
* Added a generator script `genMockTweets.ts` that creates mock tweet data using `@faker-js/faker` and saves it as `tweet.json` for use in mocks.
* Registered a new MSW handler in `handlers/tweet.ts` to support endpoints for fetching a tweet, liking/unliking, and retweeting/unretweeting, with in-memory state updates.
* Integrated the new tweet handlers into the main MSW handler list in `mocks/handler.ts`.

**Tooling and dependency updates:**

* Added `@faker-js/faker` as a dev dependency for generating mock data, and updated `pnpm-lock.yaml` accordingly. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R41) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR63-R65)
* Added a new npm script `mock:gen:tweets` to easily generate mock tweet data.