### PR TITLE
fix(build): two dialog files resolving to the same name - [CU-869aw4ezw]

### DIFF
--- a/app/components/ui/dialog/index.ts
+++ b/app/components/ui/dialog/index.ts
@@ -1,9 +1,0 @@
-export { default as Dialog } from './Dialog.vue';
-export { default as DialogClose } from './DialogClose.vue';
-export { default as DialogContent } from './DialogContent.vue';
-export { default as DialogDescription } from './DialogDescription.vue';
-export { default as DialogFooter } from './DialogFooter.vue';
-export { default as DialogHeader } from './DialogHeader.vue';
-export { default as DialogOverlay } from './DialogOverlay.vue';
-export { default as DialogTitle } from './DialogTitle.vue';
-export { default as DialogTrigger } from './DialogTrigger.vue';

--- a/test/nuxt/components/ui/Dialog.spec.ts
+++ b/test/nuxt/components/ui/Dialog.spec.ts
@@ -1,16 +1,14 @@
 // @vitest-environment nuxt
 import { describe, expect, it } from 'vitest';
 import { mountSuspended } from '@nuxt/test-utils/runtime';
-import {
-  Dialog,
-  DialogTrigger,
-  DialogContent,
-  DialogFooter,
-  DialogTitle,
-  DialogHeader,
-  DialogDescription,
-  DialogClose,
-} from '@/components/ui/dialog';
+import Dialog from '@/components/ui/dialog/Dialog.vue';
+import DialogTrigger from '@/components/ui/dialog/DialogTrigger.vue';
+import DialogContent from '@/components/ui/dialog/DialogContent.vue';
+import DialogFooter from '@/components/ui/dialog/DialogFooter.vue';
+import DialogTitle from '@/components/ui/dialog/DialogTitle.vue';
+import DialogHeader from '@/components/ui/dialog/DialogHeader.vue';
+import DialogDescription from '@/components/ui/dialog/DialogDescription.vue';
+import DialogClose from '@/components/ui/dialog/DialogClose.vue';
 
 describe('Dialog component', () => {
   it('renders trigger and content (opens on trigger click)', async () => {


### PR DESCRIPTION
## Description
This warning appears every time we try to run the app.
this is related to the auto-import feature that Nuxt offers :
```
 WARN  Two component files resolving to the same name UiDialog:                                       nuxt 3:36:20 PM

 - /home/habiba/Downloads/raven-frontend/app/components/ui/dialog/index.ts
 - /home/habiba/Downloads/raven-frontend/app/components/ui/dialog/Dialog.vue
 ```
 
 I deleted the `index.ts` because I can't find it used elsewhere except for a single file (the unit tests file)!
 The whole reason for its existence is to simplify importing dialog components from their folder in the project and since we're already using Nuxt's auto-import feature, this is no longer needed. 
 cc: @AhmedAmrNabil 