### PR TITLE
fix: use i18n routing prefix strategy - [CU-869b0233f]

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,7 +32,7 @@ export default defineNuxtConfig({
     plugins: [tailwindcss()],
   },
   i18n: {
-    strategy: 'prefix_except_default',
+    strategy: 'no_prefix',
     defaultLocale: 'en',
     locales: [
       { code: 'en', name: 'English', file: 'en.json' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,7 +32,7 @@ export default defineNuxtConfig({
     plugins: [tailwindcss()],
   },
   i18n: {
-    strategy: 'prefix',
+    strategy: 'prefix_except_default',
     defaultLocale: 'en',
     locales: [
       { code: 'en', name: 'English', file: 'en.json' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,7 +32,7 @@ export default defineNuxtConfig({
     plugins: [tailwindcss()],
   },
   i18n: {
-    strategy: 'prefix_and_default',
+    strategy: 'prefix',
     defaultLocale: 'en',
     locales: [
       { code: 'en', name: 'English', file: 'en.json' },


### PR DESCRIPTION
## Problem
Local doesn't persist on route change, it defaults back to `en`
as reported by @Abdallah-farag27 (Thanks!)

## Fix Description
Changed the `i18n-strategy` key in Nuxt config.
It now adds a current local prefix to every route.

Fix confirmation visual showing changing routes in a non-default local persisting:

[ar-local.webm](https://github.com/user-attachments/assets/79335472-66fe-4603-bce6-adb67913f59a)

## Reviewer Guidance
 - [x] Try navigating multiple pages and see if they still exist
 - [x] Do the same for a non-default local (`ar`)
 for now because the settings pages is still not on dev, you have to change this manually.
 
 >[!IMPORTANT]
 > This broke tab highlighting because we used to check on that using routes, and now that they've changed, we have to reflect that on our checks too. A fix to this will be pushed in #30 (not here to minimize future merge conflicts.) 