### PR TITLE
fix: set reCAPTCHA site key in build time - [CU-869b0k40z]

### DIFF
--- a/.github/workflows/auto-deploy.yaml
+++ b/.github/workflows/auto-deploy.yaml
@@ -75,6 +75,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            NUXT_PUBLIC_RECAPTCHA_SITE_KEY=${{ secrets.NUXT_PUBLIC_RECAPTCHA_SITE_KEY }}
           tags: |
             "${{ steps.image.outputs.registry }}:${{ steps.image.outputs.tag }}"
             "${{ steps.image.outputs.registry }}:${{ steps.image.outputs.latest_tag }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN corepack enable
 FROM base AS build
 ENV NODE_ENV=development
 
+ARG NUXT_PUBLIC_RECAPTCHA_SITE_KEY
+
+ENV NUXT_PUBLIC_RECAPTCHA_SITE_KEY=$NUXT_PUBLIC_RECAPTCHA_SITE_KEY
+
 # Install dependencies
 COPY package.json pnpm-lock.yaml ./
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \


### PR DESCRIPTION
> [!NOTE]
> ### Lesson learnt: Any value that is needed by the browser must be baked in at build time, because the frontend has no runtime secret store. The rest are "server code keys" so they're safe to just exist in `.env` and get handled by the frontend's server.