### PR TITLE
fix: oauth - [CU-869b0w5u2]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ NUXT_PUBLIC_RECAPTCHA_SITE_KEY=sitekey
 NUXT_PUBLIC_GOOGLE_CLIENT_ID=google-client-id
 NUXT_PUBLIC_GITHUB_CLIENT_ID=github-client-id
 NUXT_PUBLIC_GITHUB_SCOPE=github-scope
+NUXT_PUBLIC_GITHUB_REDIRECT_URI=https://raven.cmp27.space/oauth/github/bridge
+NUXT_PUBLIC_BASE_URL=http://localhost:5173

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -16,12 +16,18 @@ const config = useRuntimeConfig();
 const githubClientId = config.public.githubClientId;
 const githubRedirectUri = config.public.githubRedirectUri;
 const githubScope = config.public.githubScope;
+const baseUrl = config.public.baseUrl;
 
 function handleGithubSignIn() {
   const params = new URLSearchParams({
     client_id: githubClientId,
     redirect_uri: githubRedirectUri,
     scope: githubScope,
+    state: btoa(
+      JSON.stringify({
+        redirect: `${baseUrl}/auth/callback/github`,
+      }),
+    ),
   });
   window?.open(
     `https://github.com/login/oauth/authorize?${params.toString()}`,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,6 +12,7 @@ export default defineNuxtConfig({
       githubRedirectUri: process.env.NUXT_PUBLIC_GITHUB_REDIRECT_URI || '',
       githubScope: process.env.NUXT_PUBLIC_GITHUB_SCOPE || '',
       siteKey: process.env.NUXT_PUBLIC_RECAPTCHA_SITE_KEY || '',
+      baseUrl: process.env.NUXT_PUBLIC_BASE_URL || 'http://localhost:5173',
     },
   },
   devtools: {


### PR DESCRIPTION
# Fix for github oauth

## The problem:
github only allows one redirect uri for an application so we cannot have redirect url be the website domain and the mobile phone at the same time.
## The fix:
have a centralized redirect route, and send to it another redirect_url which would be frontend or mobile respectively using a "state" param in the redirect uri