### PR TITLE
chore: fix nuxt auto api type - [CU-869b13gg3]

### DIFF
--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -1,6 +1,7 @@
 import { clearAccessToken, getAccessToken } from '~/services/auth/authService';
+import type { NitroFetchRequest, $Fetch } from 'nitropack';
 
-export const apiFetch = $fetch.create({
+export const apiFetch: $Fetch<unknown, NitroFetchRequest> = $fetch.create({
   retry: 3,
   retryStatusCodes: [401],
   onRequest({ options }) {

--- a/server/utils/handler.ts
+++ b/server/utils/handler.ts
@@ -7,7 +7,7 @@ export const defineWrappedResponseHandler = <T extends EventHandlerRequest, D>(
   defineEventHandler<T>(async (event) => {
     try {
       const response = await handler(event);
-      return response;
+      return response as D;
     } catch (err) {
       if (isError(err)) {
         throw err;


### PR DESCRIPTION
- Add NitroFetchRequest typing to apiFetch for server route autocompletion.
- Improve defineWrappedResponseHandler to infer and return correct response types.
