### PR TITLE
fix(user-profile): make username a computed property - [CU-869b6xcha]

### DIFF
--- a/app/components/profile/ProfileInfo.vue
+++ b/app/components/profile/ProfileInfo.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
 import type { User } from '~~/shared/types/user';
 import { formatMonthYear } from '~/utils/date';
+
 const props = defineProps<{
   userProfile: User;
 }>();
-const displayUsername = '@' + props.userProfile.username;
+
+const displayUsername = computed(() => '@' + props.userProfile.username);
 const displayUrl = computed(() => {
   if (props.userProfile.websiteUrl) {
     const cleanedUrl = cleanUrl(props.userProfile.websiteUrl);
@@ -13,6 +15,7 @@ const displayUrl = computed(() => {
   return '';
 });
 </script>
+
 <template>
   <div class="mt-2 flex flex-col">
     <div class="px-4">


### PR DESCRIPTION
## Bug Description
When switching profiles, the username -only- didn't update in the UI unless after you refresh the page.

## Steps to reproduce
1. Login with one of the backend teams accounts
2. Go to the 'following' tab
3. Click on a user's username
4. Click on your profile icon in the left side bar
You'll notice that it didn't update the username correctly

## Reviewer Guidance
Repeat the same steps above and make sure you're unable to reproduce it. 