### PR TITLE
refactor(build): toggle mocks using a new .env variable - [CU-869b6xncv]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ NUXT_PUBLIC_GITHUB_CLIENT_ID=github-client-id
 NUXT_PUBLIC_GITHUB_SCOPE=github-scope
 NUXT_PUBLIC_GITHUB_REDIRECT_URI=https://raven.cmp27.space/oauth/github/bridge
 NUXT_PUBLIC_BASE_URL=http://localhost:5173
+NUXT_PUBLIC_USE_MOCKS=true

--- a/mocks/handler.ts
+++ b/mocks/handler.ts
@@ -7,7 +7,6 @@ import { handlers as profileHandlers } from './handlers/update-profile';
 import { handlers as authHandlers } from './handlers/auth';
 import { handlers as onboardingHandlers } from './handlers/onboarding';
 import { handlers as otherUserHandlers } from './handlers/other-user';
-// // Import more handlers as needed
 
 export const handlers = [
   ...registerHandlers,
@@ -19,5 +18,4 @@ export const handlers = [
   ...profileHandlers,
   ...otherUserHandlers,
   ...onboardingHandlers,
-  // Add More handlers here
 ];

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,6 +6,7 @@ export default defineNuxtConfig({
   css: ['@/assets/css/main.css'],
   runtimeConfig: {
     public: {
+      useMocks: process.env.NUXT_PUBLIC_USE_MOCKS === 'true',
       googleClientId: process.env.NUXT_PUBLIC_GOOGLE_CLIENT_ID || '',
       backendUrl: process.env.BACKEND_URL || '',
       githubClientId: process.env.NUXT_PUBLIC_GITHUB_CLIENT_ID || '',

--- a/server/plugins/msw.server.ts
+++ b/server/plugins/msw.server.ts
@@ -1,11 +1,13 @@
 export default defineNitroPlugin(async (nitroApp) => {
-  if (import.meta.dev) {
-    const { server } = await import('../../mocks/node');
-    server.listen({ onUnhandledRequest: 'bypass' });
-    console.warn('Mock Service Worker (server) started');
+  const config = useRuntimeConfig();
 
-    nitroApp.hooks.hook('close', () => {
-      server.close();
-    });
-  }
+  if (!import.meta.dev || !config.public.useMocks) return;
+
+  const { server } = await import('../../mocks/node');
+  server.listen({ onUnhandledRequest: 'bypass' });
+  console.warn('Mock Service Worker (server) started');
+
+  nitroApp.hooks.hook('close', () => {
+    server.close();
+  });
 });


### PR DESCRIPTION
## Description
Although toggling the usage of msw by commenting out an array inside a file that you have to search the codebase for and maybe accidentally commiting that 2000 times is very professional, a new `.env` variable to replace that is nice too.

>[!WARNING]
> This PR requires updating your local `.env`
> add this line:
> ```
> NUXT_PUBLIC_USE_MOCKS=true
> ```