### PR TITLE
refactor(user-profile): update /me endpoint to handle updates solely  - [CU-869b740fd]

### DIFF
--- a/app/pages/settings/profile.vue
+++ b/app/pages/settings/profile.vue
@@ -14,8 +14,7 @@ const isDialogOpen = computed(() => route.path === '/settings/profile');
 const openDiscardDialog = ref(false);
 
 const userStore = useUserStore();
-const { updateProfile, updateProfilePicture, updateHeaderImage, removeHeaderImage } =
-  updateProfileService();
+const { updateProfile } = updateProfileService();
 
 const bannerFileInput = ref<HTMLInputElement | null>(null);
 const profileFileInput = ref<HTMLInputElement | null>(null);
@@ -139,28 +138,24 @@ const handleSubmit = async () => {
   router.push(`/profile/${userStore.user.username}`);
   await nextTick(); // allow DOM and route to update
 
-  // Handle uploads and updates
-  if (!selectedImage.value && userStore.user.bannerUrl) {
-    await removeHeaderImage();
-  } else if (bannerFileInput.value?.files?.[0]) {
-    await updateHeaderImage(bannerFileInput.value.files[0]);
-  }
-
-  if (profileFileInput.value?.files?.[0]) {
-    await updateProfilePicture(profileFileInput.value.files[0]);
-  }
-
   const formattedBirthDate = birthDate.value
     ? birthDate.value.toISOString().split('T')[0]
     : undefined;
 
-  await updateProfile({
+  // Prepare profile data
+  const profileData = {
     displayName: name.value,
     bio: normalize(bio.value),
     location: normalize(location.value),
     websiteUrl: normalize(website.value),
     birthDate: formattedBirthDate,
-  });
+    deleteBanner: !selectedImage.value && !!userStore.user.bannerUrl,
+  };
+  // Get files
+  const bannerFile = bannerFileInput.value?.files?.[0];
+  const profileFile = profileFileInput.value?.files?.[0];
+
+  await updateProfile(profileData, profileFile, bannerFile);
 
   // refresh data
   queryClient.invalidateQueries({ queryKey: ['layout-data'] });

--- a/app/services/profile/updateProfileService.ts
+++ b/app/services/profile/updateProfileService.ts
@@ -3,11 +3,26 @@ import type { ApiSuccessResponse } from '~~/shared/types/api';
 import { apiFetch } from '~/api';
 
 export const updateProfileService = () => {
-  const updateProfile = async (profileData: UpdateProfileRequest): Promise<UserData> => {
+  const updateProfile = async (
+    profileData: UpdateProfileRequest,
+    profilePicture?: File,
+    bannerPicture?: File,
+  ): Promise<UserData> => {
     try {
+      const formData = new FormData();
+
+      // 'data': json, 'avatar': file, 'banner': file
+      formData.append('data', JSON.stringify(profileData));
+      if (profilePicture) {
+        formData.append('avatar', profilePicture);
+      }
+      if (bannerPicture) {
+        formData.append('banner', bannerPicture);
+      }
+
       const response = await apiFetch<ApiSuccessResponse<UserData>>('/api/me', {
         method: 'PATCH',
-        body: profileData,
+        body: formData,
       });
 
       return response.data;

--- a/mocks/handlers/update-profile.ts
+++ b/mocks/handlers/update-profile.ts
@@ -38,10 +38,50 @@ export const handlers = [
   // Update profile PATCH request
   http.patch(`${API_URL}/me`, async ({ request }) => {
     try {
-      const body = (await request.json()) as UpdateProfileRequest;
+      const formData = await request.formData();
 
-      // Update the mock user data with new values
-      Object.assign(mockUserData, body);
+      // Parse the 'data' field which contains JSON
+      const dataString = formData.get('data') as string;
+      if (!dataString) {
+        return HttpResponse.json(
+          {
+            success: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'Profile data is required',
+            },
+          },
+          { status: 400 },
+        );
+      }
+
+      const profileData = JSON.parse(dataString) as UpdateProfileRequest & {
+        deleteBanner?: boolean;
+      };
+
+      // Get files if provided
+      const profilePicture = formData.get('profilePicture') as File | null;
+      const bannerImage = formData.get('bannerImage') as File | null;
+
+      // Update profile data
+      Object.assign(mockUserData, profileData);
+
+      // Handle banner deletion
+      if (profileData.deleteBanner) {
+        mockUserData.bannerUrl = null;
+      }
+
+      // Handle profile picture upload
+      if (profilePicture) {
+        const mockProfileUrl = 'https://ibb.co/rGzj2kS4';
+        mockUserData.avatarUrl = mockProfileUrl;
+      }
+
+      // Handle banner image upload
+      if (bannerImage) {
+        const mockBannerUrl = 'https://i.ibb.co/Z1Yx04kS/dfghj.webp';
+        mockUserData.bannerUrl = mockBannerUrl;
+      }
 
       const response: ApiSuccessResponse<UserData> = {
         success: true,

--- a/server/api/me/index.patch.ts
+++ b/server/api/me/index.patch.ts
@@ -1,19 +1,16 @@
-// import { FetchError } from 'ofetch';
-import type { UpdateProfileRequest } from '~~/shared/types/shared';
 import type { ApiSuccessResponse } from '../../../shared/types/api';
 
 const API_URL = process.env.BACKEND_URL;
 
 export default defineWrappedResponseHandler(async (event) => {
-  const body = await readBody<UpdateProfileRequest>(event);
-
   const authHeader = getHeader(event, 'authorization');
   const response = await serverApiFetch<ApiSuccessResponse<User>>(`${API_URL}/me`, {
     method: 'PATCH',
+    body: event.node.req,
     headers: {
       authorization: authHeader || '',
+      'content-type': event.node.req.headers['content-type']!,
     },
-    body,
   });
 
   return response;


### PR DESCRIPTION
## Description
I'm following an incremental approach to work along the new modifications + our original refactoring plans.

This PR only includes updates needed to work with the new API spec for the `/me` endpoint. 
As for our other plans for better **localized** error handling, this will be in a follow up PR.

## Reviewer Guidance
Try to edit your profile with different combinations:
- avatar only
- avatar + banner
- remove banner
- any data + avatar/banner