### PR TITLE
fix(user-profile): handle overflow for profile info sections - [CU-869b96pg7]

### DIFF
--- a/app/components/profile/ProfileInfo.vue
+++ b/app/components/profile/ProfileInfo.vue
@@ -20,9 +20,14 @@ const displayUrl = computed(() => {
 <template>
   <div class="mt-2 flex flex-col">
     <div class="px-4">
-      <h2 class="text-foreground pb-0 text-2xl font-bold">{{ userProfile?.displayName }}</h2>
+      <h2 class="text-foreground line-clamp-2 pb-0 text-2xl font-bold break-words">
+        {{ userProfile?.displayName }}
+      </h2>
       <p class="text-muted-foreground text-md">{{ displayUsername }}</p>
-      <p v-if="!isBlocking" class="text-muted-foreground mt-2 whitespace-pre-line">
+      <p
+        v-if="!isBlocking"
+        class="text-muted-foreground mt-2 line-clamp-4 break-words whitespace-pre-line"
+      >
         {{ userProfile?.bio }}
       </p>
 


### PR DESCRIPTION
## Description
fixed the overflow in bio/display name in user profile

before:
<img width="1139" height="166" alt="Screenshot from 2025-11-24 15-57-33" src="https://github.com/user-attachments/assets/2c1a54cc-cc30-4550-b395-d80ff1aaed8c" />


after:
<img width="641" height="564" alt="Screenshot from 2025-11-24 19-10-53" src="https://github.com/user-attachments/assets/803b9b60-9bb3-4e07-aba8-16f2d1af4c16" />
