### PR TITLE
fix: video player integration with nuxt - [CU-869baghca]

### DIFF
--- a/app/components/ui/VideoPlayer.vue
+++ b/app/components/ui/VideoPlayer.vue
@@ -2,28 +2,11 @@
 // Import the Vue wrapper
 import { VideoPlayer } from '@videojs-player/vue';
 
-// Import the default videojs to access Player type
-import type videojs from 'video.js';
-
-import 'video.js/dist/video-js.css';
-
 interface Props {
   src: string;
   poster?: string;
 }
-
 const props = defineProps<Props>();
-type VideoJsPlayer = ReturnType<typeof videojs>;
-
-function onPlayerReady(player: VideoJsPlayer) {
-  player.on('click', () => {
-    if (player.paused()) {
-      player.play();
-    } else {
-      player.pause();
-    }
-  });
-}
 </script>
 
 <template>
@@ -44,6 +27,5 @@ function onPlayerReady(player: VideoJsPlayer) {
         },
       ],
     }"
-    @mounted="onPlayerReady"
   />
 </template>

--- a/app/plugins/videojs-player.ts
+++ b/app/plugins/videojs-player.ts
@@ -1,0 +1,6 @@
+import VueVideoPlayer from '@videojs-player/vue';
+import 'video.js/dist/video-js.css';
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(VueVideoPlayer);
+});


### PR DESCRIPTION
in normal vue, to use the VideoPlayer from the library you would need to do:
```typescript
import { createApp } from 'vue'
import VueVideoPlayer from '@videojs-player/vue'
import 'video.js/dist/video-js.css'

const app = createApp()

app.use(VueVideoPlayer)
```

but in nuxt we need to create a plugin to use the `app.use` method

### Note:
this won't fix clicking on the player redirecting to the tweet page