### PR TITLE
fix: login page flash when no access_token found - [CU-869bc6qx1]

### DIFF
--- a/server/middleware/auth.global.ts
+++ b/server/middleware/auth.global.ts
@@ -21,6 +21,7 @@ export default defineEventHandler(async (event) => {
       },
     );
     setAuthCookies(event, response);
+    if (event.node.req.url === '/') sendRedirect(event, '/home', 302);
   } catch {
     deleteCookie(event, 'refreshToken');
     deleteCookie(event, 'access_token');


### PR DESCRIPTION
Basically if access token expires, and you try to open raven....com/
it refresh the token in the server side but doesn't redirect to the home page on the server, it waits for client hydration
this pr fixes it by redirecting to home page from server side.