### PR TITLE
feat: update search suggestions endpoint - [CU-869bf739r]

### DIFF
--- a/app/components/search/HistoryItem.vue
+++ b/app/components/search/HistoryItem.vue
@@ -56,7 +56,7 @@ const deleteFromHistory = (event: Event) => {
       <div class="flex min-w-0 flex-1 items-center gap-3">
         <Icon size="20" name="ic:outline-search" class="text-muted-foreground flex-shrink-0" />
         <p class="text-foreground text-md overflow-hidden break-words">
-          {{ props.type === 'hashtag' ? $t('#') + props.content : props.content }}
+          {{ props.content }}
         </p>
       </div>
       <UiButton

--- a/app/services/search/searchService.ts
+++ b/app/services/search/searchService.ts
@@ -3,7 +3,7 @@ import { PeopleFilter, type SearchQuery, type TweetsSearchQuery } from '~~/share
 
 export const searchService = {
   async getTopThreeHashtags(query: string) {
-    return await apiFetch(`/api/search/hashtags/top`, {
+    return await apiFetch(`/api/search/suggestions`, {
       method: 'GET',
       query: {
         query: query,

--- a/mocks/handlers/search.ts
+++ b/mocks/handlers/search.ts
@@ -16,8 +16,8 @@ const allHashtags = [
 ];
 
 export const handlers = [
-  // GET /search/hashtags/top - Get top 3 hashtags matching query
-  http.get(`${API_URL}/search/hashtags/top`, ({ request }) => {
+  // GET /search/suggestions - Get top 3 hashtags matching query
+  http.get(`${API_URL}/search/suggestions`, ({ request }) => {
     const url = new URL(request.url);
     const query = url.searchParams.get('query') || '';
 

--- a/server/api/search/suggestions.get.ts
+++ b/server/api/search/suggestions.get.ts
@@ -4,7 +4,7 @@ export default defineWrappedResponseHandler(async (event) => {
   const fetcher = serverApiFetch(event);
   const query = getQuery(event);
 
-  return await fetcher<ApiSuccessResponse<string[]>>('/search/hashtags/top', {
+  return await fetcher<ApiSuccessResponse<string[]>>('/search/suggestions', {
     method: 'GET',
     query: {
       query: query.query,

--- a/test/nuxt/components/search/HistoryItem.spec.ts
+++ b/test/nuxt/components/search/HistoryItem.spec.ts
@@ -118,12 +118,12 @@ describe('Search HistoryItem Component', () => {
   });
 
   describe('Hashtag type', () => {
-    it('renders hashtag with # prefix', async () => {
+    it('renders hashtag', async () => {
       const wrapper = await mountSuspended(HistoryItem, {
         props: { type: 'hashtag', content: 'javascript' },
         global: globalConfig,
       });
-      expect(wrapper.text()).toContain('#javascript');
+      expect(wrapper.text()).toContain('javascript');
     });
 
     it('links to hashtag search results', async () => {

--- a/test/nuxt/server/api/search/suggestions.get.spec.ts
+++ b/test/nuxt/server/api/search/suggestions.get.spec.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMockH3Event } from '~~/test/mocks/h3-event';
 import { useH3TestUtils } from '~~/test/mocks/h3-test-utils';
-import topSearchEventHandler from '~~/server/api/search/hashtags/top.get';
+import topSearchEventHandler from '~~/server/api/search/suggestions.get';
 
 useH3TestUtils();
 
 const mockServerApiFetch = vi.fn();
 vi.stubGlobal('serverApiFetch', () => mockServerApiFetch);
 
-describe('GET /api/search/hashtags/top', () => {
+describe('GET /api/search/suggestions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -30,7 +30,7 @@ describe('GET /api/search/hashtags/top', () => {
 
     const response = await topSearchEventHandler(event);
 
-    expect(mockServerApiFetch).toHaveBeenCalledWith('/search/hashtags/top', {
+    expect(mockServerApiFetch).toHaveBeenCalledWith('/search/suggestions', {
       method: 'GET',
       query: {
         query: 'java',
@@ -78,7 +78,7 @@ describe('GET /api/search/hashtags/top', () => {
 
     const response = await topSearchEventHandler(event);
 
-    expect(mockServerApiFetch).toHaveBeenCalledWith('/search/hashtags/top', {
+    expect(mockServerApiFetch).toHaveBeenCalledWith('/search/suggestions', {
       method: 'GET',
       query: {
         query: '',

--- a/test/nuxt/services/search/searchService.spec.ts
+++ b/test/nuxt/services/search/searchService.spec.ts
@@ -14,7 +14,7 @@ describe('searchService', () => {
     it('calls API with correct query parameter', async () => {
       const mockHashtags = ['javascript', 'typescript', 'nodejs'];
 
-      registerEndpoint('/api/search/hashtags/top', () => {
+      registerEndpoint('/api/search/suggestions', () => {
         return {
           data: mockHashtags,
         };
@@ -27,7 +27,7 @@ describe('searchService', () => {
     });
 
     it('handles empty hashtags response', async () => {
-      registerEndpoint('/api/search/hashtags/top', () => {
+      registerEndpoint('/api/search/suggestions', () => {
         return {
           data: [],
         };
@@ -65,7 +65,7 @@ describe('searchService', () => {
         };
       });
 
-      registerEndpoint('/api/search/hashtags/top', () => {
+      registerEndpoint('/api/search/suggestions', () => {
         return {
           data: mockHashtags,
         };
@@ -86,7 +86,7 @@ describe('searchService', () => {
         };
       });
 
-      registerEndpoint('/api/search/hashtags/top', () => {
+      registerEndpoint('/api/search/suggestions', () => {
         return {
           data: [],
         };


### PR DESCRIPTION
This pull request refactors the hashtag search suggestion API and related components for clarity and consistency. The main change is renaming the endpoint from `/search/hashtags/top` to `/search/suggestions`, with all associated code, mocks, and tests updated accordingly. Additionally, the display of hashtags in the search history has been simplified to remove the `#` prefix.