### PR TITLE
fix(settings): tweet action buttons propagation - [CU-869bfn569]

### DIFF
--- a/app/components/tweet/TweetActionButtons.vue
+++ b/app/components/tweet/TweetActionButtons.vue
@@ -105,7 +105,12 @@ const handleShare = async () => {
 <template>
   <div class="text-muted-foreground text-md mt-1.5 flex w-full items-center justify-between">
     <label class="hover:text-brand-blue relative flex items-center justify-center gap-[1px]">
-      <Button variant="tweet-icon-turquoise" size="icon-md" data-cy="tweet-reply-button" @click.stop>
+      <Button
+        variant="tweet-icon-turquoise"
+        size="icon-md"
+        data-cy="tweet-reply-button"
+        @click.stop
+      >
         <Icon name="tabler:message-circle-2" size="1.2rem" />
       </Button>
       <span class="absolute start-8" data-cy="tweet-reply-count">{{ props.tweet.replyCount }}</span>
@@ -127,8 +132,8 @@ const handleShare = async () => {
             "
             size="icon-md"
             data-testid="retweet-dropdown-trigger"
-            @click.stop
             data-cy="tweet-retweet-button"
+            @click.stop
           >
             <Icon name="tabler:repeat" size="1.2rem" />
           </Button>
@@ -166,8 +171,8 @@ const handleShare = async () => {
       <Button
         variant="tweet-icon-red-active"
         size="icon-md"
-        @click.stop
         data-cy="tweet-unlike-button"
+        @click.stop
         @click.prevent.stop="handleUnlike"
       >
         <Icon name="line-md:heart-filled" size="1.2rem" />
@@ -176,7 +181,13 @@ const handleShare = async () => {
     </label>
 
     <label v-else class="hover:text-brand-red relative flex items-center justify-center gap-[1px]">
-      <Button variant="tweet-icon-red" size="icon-md" @click.prevent.stop="handleLike" data-cy="tweet-like-button" @click.stop>
+      <Button
+        variant="tweet-icon-red"
+        size="icon-md"
+        data-cy="tweet-like-button"
+        @click.prevent.stop="handleLike"
+        @click.stop
+      >
         <Icon name="tabler:heart" size="1.2rem" />
       </Button>
       <span class="absolute start-8" data-cy="tweet-likes-count">{{ props.tweet.likeCount }}</span>

--- a/app/components/tweet/TweetActionButtons.vue
+++ b/app/components/tweet/TweetActionButtons.vue
@@ -105,7 +105,7 @@ const handleShare = async () => {
 <template>
   <div class="text-muted-foreground text-md mt-1.5 flex w-full items-center justify-between">
     <label class="hover:text-brand-blue relative flex items-center justify-center gap-[1px]">
-      <Button variant="tweet-icon-turquoise" size="icon-md">
+      <Button variant="tweet-icon-turquoise" size="icon-md" @click.stop>
         <Icon name="tabler:message-circle-2" size="1.2rem" />
       </Button>
       <span class="absolute start-8">{{ props.tweet.replyCount }}</span>
@@ -127,6 +127,7 @@ const handleShare = async () => {
             "
             size="icon-md"
             data-testid="retweet-dropdown-trigger"
+            @click.stop
           >
             <Icon name="tabler:repeat" size="1.2rem" />
           </Button>
@@ -154,14 +155,19 @@ const handleShare = async () => {
       v-if="props.tweet.isLiked"
       class="hover:text-brand-red text-brand-red relative flex items-center justify-center"
     >
-      <Button variant="tweet-icon-red-active" size="icon-md" @click.prevent.stop="handleUnlike">
+      <Button
+        variant="tweet-icon-red-active"
+        size="icon-md"
+        @click.prevent.stop="handleUnlike"
+        @click.stop
+      >
         <Icon name="line-md:heart-filled" size="1.2rem" />
       </Button>
       <span class="absolute start-8">{{ props.tweet.likeCount }}</span>
     </label>
 
     <label v-else class="hover:text-brand-red relative flex items-center justify-center gap-[1px]">
-      <Button variant="tweet-icon-red" size="icon-md" @click.prevent.stop="handleLike">
+      <Button variant="tweet-icon-red" size="icon-md" @click.prevent.stop="handleLike" @click.stop>
         <Icon name="tabler:heart" size="1.2rem" />
       </Button>
       <span class="absolute start-8">{{ props.tweet.likeCount }}</span>
@@ -172,6 +178,7 @@ const handleShare = async () => {
       size="icon-md"
       class="hover:text-brand-blue"
       @click.prevent.stop="handleShare"
+      @click.stop
     >
       <Icon name="lucide:share" size="1.2rem" />
     </Button>

--- a/app/components/tweet/TweetDefaultCard.vue
+++ b/app/components/tweet/TweetDefaultCard.vue
@@ -228,7 +228,6 @@ const { mutate: blockUser } = useBlockMutation();
       <!-- Actions -->
       <TweetActionButtons
         :tweet="tweet"
-        @click.stop
         @like-success="onLikeSuccess"
         @unlike-success="onUnlikeSuccess"
         @retweet-success="onRetweetSuccess"

--- a/app/components/tweet/TweetView.vue
+++ b/app/components/tweet/TweetView.vue
@@ -174,6 +174,7 @@ function handleReplied(tweet: Tweet) {
         <div class="relative">
           <div class="absolute end-0 top-1 flex translate-x-2.5 flex-row items-center">
             <UiButton
+              v-if="!(!tweetClone.content || tweetClone.content.trim().length === 0)"
               variant="ghost-default"
               size="icon-sm"
               class="text-muted-foreground"
@@ -183,7 +184,6 @@ function handleReplied(tweet: Tweet) {
             </UiButton>
             <TweetDropdown :tweet="props.tweet" :username="originalUsername">
               <UiButton
-                v-if="!(!tweetClone.content || tweetClone.content.trim().length === 0)"
                 variant="ghost-default"
                 size="icon-xs"
                 class="text-muted-foreground"


### PR DESCRIPTION
This pull request focuses on improving the click event handling for tweet action buttons in the `TweetActionButtons.vue` component. The main goal is to ensure that click events on these buttons do not unintentionally propagate to parent elements, which could cause unexpected behavior (such as triggering navigation or other handlers). The changes consistently apply `@click.stop` to relevant buttons, and remove redundant event modifiers from the parent component.

**Event handling improvements in tweet action buttons:**

* Added `@click.stop` to all action buttons in `TweetActionButtons.vue` (reply, retweet, like, unlike, and share) to prevent event bubbling and ensure only the intended action is triggered. [[1]](diffhunk://#diff-22df3ae2f65776bb6b8357d7d33095ccf8db4be0b0e91697959b488bafff55f8L108-R108) [[2]](diffhunk://#diff-22df3ae2f65776bb6b8357d7d33095ccf8db4be0b0e91697959b488bafff55f8R130) [[3]](diffhunk://#diff-22df3ae2f65776bb6b8357d7d33095ccf8db4be0b0e91697959b488bafff55f8L157-R170) [[4]](diffhunk://#diff-22df3ae2f65776bb6b8357d7d33095ccf8db4be0b0e91697959b488bafff55f8R181)
* Removed the redundant `@click.stop` from the `TweetActionButtons` component usage in `TweetDefaultCard.vue`, since event propagation is now handled within the child component.