### PR TITLE
fix(tweet): delete tweet in tweet view - [CU-869bfyx58]

### DIFF
--- a/app/components/tweet/TweetDropdown.vue
+++ b/app/components/tweet/TweetDropdown.vue
@@ -4,10 +4,16 @@ import { deleteTweet } from '~/services/tweet/actionButtonsService';
 import { showToaster } from '~/utils/showToaster';
 import type { Tweet } from '~~/shared/types/tweets';
 
-const props = defineProps<{
-  tweet: Tweet;
-  username: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    tweet: Tweet;
+    username: string;
+    tweetView?: boolean;
+  }>(),
+  {
+    tweetView: false,
+  },
+);
 
 const queryClient = useQueryClient();
 
@@ -30,6 +36,8 @@ function removeTweetFromInfiniteData(
   };
 }
 
+const router = useRouter();
+
 async function handleDelete() {
   try {
     await deleteTweet(props.tweet.id);
@@ -49,6 +57,10 @@ async function handleDelete() {
         removeTweetFromInfiniteData(oldData, props.tweet.id),
       );
     });
+    if (props.tweetView) {
+      await router.back();
+      return;
+    }
   } catch {
     showToaster('error', $t('tweet.delete-error'));
   }

--- a/app/components/tweet/TweetView.vue
+++ b/app/components/tweet/TweetView.vue
@@ -183,7 +183,7 @@ function handleReplied(tweet: Tweet) {
             >
               <Icon name="vscode-icons:file-type-gemini" size="1.2rem" />
             </UiButton>
-            <TweetDropdown :tweet="props.tweet" :username="originalUsername" tweet-view>
+            <TweetDropdown :tweet="props.tweet" :username="originalUsername" :tweet-view="true">
               <UiButton
                 variant="ghost-default"
                 size="icon-xs"

--- a/app/components/tweet/TweetView.vue
+++ b/app/components/tweet/TweetView.vue
@@ -183,7 +183,7 @@ function handleReplied(tweet: Tweet) {
             >
               <Icon name="vscode-icons:file-type-gemini" size="1.2rem" />
             </UiButton>
-            <TweetDropdown :tweet="props.tweet" :username="originalUsername">
+            <TweetDropdown :tweet="props.tweet" :username="originalUsername" tweet-view>
               <UiButton
                 variant="ghost-default"
                 size="icon-xs"


### PR DESCRIPTION
This pull request enhances the behavior of the `TweetDropdown` component, particularly when deleting a tweet from the tweet detail view. The changes ensure that after deleting a tweet while viewing its detail page, the user is navigated back to the previous page. Additionally, the component now accepts a new prop to distinguish between the tweet list and tweet detail contexts.

Key improvements:

**Tweet deletion flow:**
* Added logic to navigate back to the previous page (`router.back()`) after deleting a tweet when the `TweetDropdown` is used in the tweet detail view (`tweetView`).

**Component API enhancements:**
* Introduced a new optional boolean prop `tweetView` (defaulting to `false`) in the `TweetDropdown` component to indicate when it is rendered in the tweet detail view.
* Updated the usage of `TweetDropdown` in `TweetView.vue` to pass the `tweet-view` prop, ensuring the new navigation behavior is triggered when appropriate.

**Code organization:**
* Added the `useRouter` hook to `TweetDropdown.vue` to enable programmatic navigation.